### PR TITLE
LOM-283 Add configuration hdbt_subtheme to enable latest favicon

### DIFF
--- a/conf/cmi/hdbt_subtheme.settings.yml
+++ b/conf/cmi/hdbt_subtheme.settings.yml
@@ -1,0 +1,10 @@
+features:
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 0
+  path: ''


### PR DESCRIPTION
# [LOM-283](https://helsinkisolutionoffice.atlassian.net/browse/LOM-283)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated favicon to latest version.

## How to install

* Checkout the branch and run make commands.
  * `git checkout origin LOM-283_favicon`
  * `make drush-cim && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the favicon is changed to the new H-version. 
* [ ] Check that code follows our standards