### PR TITLE
LOM-294 Updated permissions so that admin and editor have correct ones

### DIFF
--- a/conf/cmi/update.settings.yml
+++ b/conf/cmi/update.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: 2QzULf0zovJQx3J06Y9rufzzfi-CY2CTTlEfJJh2Qyw
 check:
   disabled_extensions: false
   interval_days: 1
@@ -7,7 +9,5 @@ fetch:
   timeout: 30
 notification:
   emails:
-    - admin@example.com
+    - drupal@hel.fi
   threshold: all
-_core:
-  default_config_hash: 2QzULf0zovJQx3J06Y9rufzzfi-CY2CTTlEfJJh2Qyw

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.full_html
     - media.type.file
+    - media.type.helfi_chart
     - media.type.image
     - media.type.remote_video
     - media.type.soundcloud
@@ -45,12 +46,13 @@ dependencies:
     - view_unpublished
     - views_bulk_edit
     - webform
+    - webform_node
     - webform_templates
 _core:
   default_config_hash: 7RTyCpgMKCMdwkxYrpzYOCq7DQDHO0SrTjB7xwFaIyI
 id: admin
 label: Administrator
-weight: -1
+weight: -5
 is_admin: null
 permissions:
   - 'access administration pages'
@@ -63,6 +65,8 @@ permissions:
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'
+  - 'access webform help'
+  - 'access webform overview'
   - 'administer blocks'
   - 'administer eu cookie compliance categories'
   - 'administer eu cookie compliance popup'
@@ -82,12 +86,17 @@ permissions:
   - 'assign content_producer role'
   - 'assign editor role'
   - 'assign read_only role'
+  - 'assign verkkolomake_admin role'
+  - 'assign verkkolomake_hallinnoija role'
+  - 'assign verkkolomake_kasittelija role'
+  - 'assign verkkolomake_kasittelija_todistus role'
   - 'break content lock'
   - 'cancel account'
   - 'change own username'
   - 'create announcement content'
   - 'create content translations'
   - 'create file media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create landing_page content'
   - 'create media'
@@ -98,11 +107,14 @@ permissions:
   - 'create soundcloud media'
   - 'create terms in keywords'
   - 'create url aliases'
+  - 'create webform'
+  - 'create webform content'
   - 'delete all revisions'
   - 'delete announcement revisions'
   - 'delete any announcement content'
   - 'delete any article content'
   - 'delete any file media'
+  - 'delete any helfi_chart media'
   - 'delete any image media'
   - 'delete any landing_page content'
   - 'delete any media'
@@ -116,16 +128,22 @@ permissions:
   - 'delete media'
   - 'delete own announcement content'
   - 'delete own file media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own landing_page content'
   - 'delete own page content'
   - 'delete own remote_video media'
   - 'delete own soundcloud media'
+  - 'delete own webform'
+  - 'delete own webform content'
+  - 'delete own webform submission'
   - 'delete page revisions'
   - 'delete remote entities'
   - 'delete terms in keywords'
+  - 'delete webform revisions'
   - 'edit any announcement content'
   - 'edit any file media'
+  - 'edit any helfi_chart media'
   - 'edit any image media'
   - 'edit any landing_page content'
   - 'edit any page content'
@@ -134,11 +152,15 @@ permissions:
   - 'edit any webform content'
   - 'edit own announcement content'
   - 'edit own file media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own landing_page content'
   - 'edit own page content'
   - 'edit own remote_video media'
   - 'edit own soundcloud media'
+  - 'edit own webform'
+  - 'edit own webform content'
+  - 'edit own webform submission'
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
@@ -165,6 +187,7 @@ permissions:
   - 'translate page node'
   - 'translate remote_video media'
   - 'translate soundcloud media'
+  - 'translate webform node'
   - 'update any media'
   - 'update content translations'
   - 'update media'
@@ -182,9 +205,11 @@ permissions:
   - 'view media'
   - 'view own unpublished content'
   - 'view own unpublished media'
+  - 'view own webform submission'
   - 'view page revisions'
   - 'view remote entities'
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
   - 'view webform revisions'
+  - 'view webform submissions own node'

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -14,7 +14,7 @@ _core:
   default_config_hash: 83Nuup-6oYkkdAsvg3nrR2pBOgtTXEV1JrzpCCLkYLM
 id: authenticated
 label: 'Authenticated user'
-weight: -8
+weight: -9
 is_admin: false
 permissions:
   - 'access content'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.full_html
     - media.type.file
+    - media.type.helfi_chart
     - media.type.image
     - media.type.remote_video
     - media.type.soundcloud
@@ -33,7 +34,7 @@ _core:
   default_config_hash: EVzxFtbOrGVTXWw2GTh1fEzzqruPEqSo84k10-BF6eA
 id: content_producer
 label: 'Content producer'
-weight: -5
+weight: -7
 is_admin: null
 permissions:
   - 'access content overview'
@@ -50,6 +51,7 @@ permissions:
   - 'change own username'
   - 'create announcement content'
   - 'create file media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create landing_page content'
   - 'create media'
@@ -62,6 +64,7 @@ permissions:
   - 'delete media'
   - 'delete own announcement content'
   - 'delete own file media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own landing_page content'
   - 'delete own page content'
@@ -77,16 +80,19 @@ permissions:
   - 'edit any webform content'
   - 'edit own announcement content'
   - 'edit own file media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own landing_page content'
   - 'edit own page content'
   - 'edit own remote_video media'
   - 'edit own soundcloud media'
+  - 'edit own webform content'
   - 'edit paragraph library item'
   - 'edit terms in keywords'
   - 'revert announcement revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
+  - 'revert webform revisions'
   - 'schedule publishing of nodes'
   - 'set announcement published on date'
   - 'set landing_page published on date'
@@ -109,3 +115,4 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view webform revisions'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - filter.format.full_html
     - media.type.file
+    - media.type.helfi_chart
     - media.type.image
     - media.type.remote_video
     - media.type.soundcloud
     - node.type.announcement
     - node.type.landing_page
     - node.type.page
+    - node.type.webform
     - taxonomy.vocabulary.keywords
   module:
     - content_translation
@@ -33,7 +35,7 @@ dependencies:
     - view_unpublished
 id: editor
 label: Editor
-weight: 4
+weight: -6
 is_admin: null
 permissions:
   - 'access administration pages'
@@ -54,6 +56,7 @@ permissions:
   - 'create announcement content'
   - 'create content translations'
   - 'create file media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create landing_page content'
   - 'create media'
@@ -64,48 +67,59 @@ permissions:
   - 'create soundcloud media'
   - 'create terms in keywords'
   - 'create url aliases'
+  - 'create webform content'
   - 'delete announcement revisions'
   - 'delete any announcement content'
   - 'delete any file media'
+  - 'delete any helfi_chart media'
   - 'delete any image media'
   - 'delete any landing_page content'
   - 'delete any media'
   - 'delete any page content'
   - 'delete any remote_video media'
   - 'delete any soundcloud media'
+  - 'delete any webform content'
   - 'delete content translations'
   - 'delete landing_page revisions'
   - 'delete media'
   - 'delete own announcement content'
   - 'delete own file media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own landing_page content'
   - 'delete own page content'
   - 'delete own remote_video media'
   - 'delete own soundcloud media'
+  - 'delete own webform content'
   - 'delete page revisions'
   - 'delete remote entities'
   - 'delete terms in keywords'
+  - 'delete webform revisions'
   - 'edit any announcement content'
   - 'edit any file media'
+  - 'edit any helfi_chart media'
   - 'edit any image media'
   - 'edit any landing_page content'
   - 'edit any page content'
   - 'edit any remote_video media'
   - 'edit any soundcloud media'
+  - 'edit any webform content'
   - 'edit own announcement content'
   - 'edit own file media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own landing_page content'
   - 'edit own page content'
   - 'edit own remote_video media'
   - 'edit own soundcloud media'
+  - 'edit own webform content'
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
   - 'revert announcement revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
+  - 'revert webform revisions'
   - 'schedule publishing of nodes'
   - 'set announcement published on date'
   - 'set landing_page published on date'
@@ -122,6 +136,7 @@ permissions:
   - 'translate page node'
   - 'translate remote_video media'
   - 'translate soundcloud media'
+  - 'translate webform node'
   - 'update any media'
   - 'update content translations'
   - 'update media'
@@ -139,3 +154,4 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view webform revisions'

--- a/conf/cmi/user.role.helsinkiprofiili_heikko.yml
+++ b/conf/cmi/user.role.helsinkiprofiili_heikko.yml
@@ -6,7 +6,7 @@ dependencies:
     - form_tool_share
 id: helsinkiprofiili_heikko
 label: 'HelsinkiProfiili Heikko'
-weight: -7
+weight: -4
 is_admin: null
 permissions:
   - 'access form data page'

--- a/conf/cmi/user.role.helsinkiprofiili_vahva.yml
+++ b/conf/cmi/user.role.helsinkiprofiili_vahva.yml
@@ -7,7 +7,7 @@ dependencies:
     - webform
 id: helsinkiprofiili_vahva
 label: 'HelsinkiProfiili Vahva'
-weight: -6
+weight: -3
 is_admin: null
 permissions:
   - 'access form data page'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -8,7 +8,7 @@ dependencies:
     - view_unpublished
 id: read_only
 label: 'Read only'
-weight: -9
+weight: -8
 is_admin: null
 permissions:
   - 'access toolbar'

--- a/conf/cmi/user.role.verkkolomake_admin.yml
+++ b/conf/cmi/user.role.verkkolomake_admin.yml
@@ -4,6 +4,6 @@ status: true
 dependencies: {  }
 id: verkkolomake_admin
 label: Verkkolomake-admin
-weight: -2
+weight: 0
 is_admin: null
 permissions: {  }

--- a/conf/cmi/user.role.verkkolomake_hallinnoija.yml
+++ b/conf/cmi/user.role.verkkolomake_hallinnoija.yml
@@ -15,7 +15,7 @@ dependencies:
     - webform_node
 id: verkkolomake_hallinnoija
 label: Verkkolomake-hallinnoija
-weight: -3
+weight: -1
 is_admin: null
 permissions:
   - 'access administration pages'

--- a/conf/cmi/user.role.verkkolomake_kasittelija.yml
+++ b/conf/cmi/user.role.verkkolomake_kasittelija.yml
@@ -6,7 +6,7 @@ dependencies:
     - form_tool_share
 id: verkkolomake_kasittelija
 label: Verkkolomake-käsittelijä
-weight: -4
+weight: -2
 is_admin: null
 permissions:
   - 'access form data page'


### PR DESCRIPTION
# [LOM-294](https://helsinkisolutionoffice.atlassian.net/browse/LOM-294)

## What was done
<!-- Describe what was done -->

* Updated the editor and admin role permissions so that these users can create, translate, edit and remove the webform-nodes.

## How to install

* Checkout the branch and run make commands.
  * `git checkout origin LOM-294_webform_node_type_permissions`
  * `make drush-cim && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Log in as UID-1 and create two users. For one of the users give the Editor role. For the other give the Administrator role.
* [x] Log in with the Editor role user and make sure you can create webform nodes https://hel-fi-form-tool.docker.so/en/node/add/webform and edit and delete them. Notice that by the hel.fi specs the Editor cannot break locks but Administrator can.
* [x] Next log in with the Administrator user and make sure you are able break the locks and view the webforms attached to the webform nodes unlike the editor.
* [x] Check that code follows our standards