### PR TITLE
LOM-269 Add missing translations and settings for cookie banner funct…

### DIFF
--- a/conf/cmi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/eu_cookie_compliance.settings.yml
@@ -5,8 +5,8 @@ uuid: 794fc11b-a1b4-41a7-a351-aaa84516c2c5
 popup_enabled: true
 popup_clicking_confirmation: false
 popup_scrolling_confirmation: false
-eu_only: null
-eu_only_js: null
+eu_only: false
+eu_only_js: false
 popup_position: false
 fixed_top_position: true
 popup_info:
@@ -27,7 +27,7 @@ popup_agreed:
   format: full_html
 popup_find_more_button_message: 'Show cookies'
 popup_hide_button_message: Hide
-popup_link: /node/1
+popup_link: /cookie-information-and-settings
 popup_link_new_window: false
 popup_height: null
 popup_width: ''
@@ -45,6 +45,7 @@ set_cookie_session_zero_on_disagree: 0
 cookie_lifetime: 100
 use_mobile_message: false
 use_bare_css: true
+use_olivero_css: false
 disagree_do_not_show_popup: false
 reload_page: true
 reload_options: 0
@@ -79,3 +80,6 @@ close_button_action: close_banner
 reject_button_label: ''
 reject_button_enabled: false
 close_button_enabled: false
+dependencies:
+  config:
+    - filter.format.full_html

--- a/conf/cmi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/eu_cookie_compliance.settings.yml
@@ -64,7 +64,7 @@ withdraw_tab_button_label: 'Privacy settings'
 withdraw_action_button_label: 'Withdraw consent'
 withdraw_enabled: false
 withdraw_button_on_info_popup: false
-save_preferences_button_label: 'Allow only essential cookies'
+save_preferences_button_label: 'Accept only essential cookies'
 accept_all_categories_button_label: 'Accept all cookies'
 enable_save_preferences_button: true
 domain_all_sites: true

--- a/conf/cmi/hdbt_admin_tools.cookie_consent_intro.yml
+++ b/conf/cmi/hdbt_admin_tools.cookie_consent_intro.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 9h2XrbXjVIuqMQ2n2xyf10paCY4DQ4Y1yDu4oPGJBiE
+cc:
+  title: 'Cookie settings'
+  content:
+    value: "<p>A cookie is a small-scale data storage program that a computer browser installs on a user's computer hard drive. Whenever the user's browser retrieves the site from the City of Helsinki's servers, the message is sent back to the user's computer. Javascript and server logs are used to record, for example, the number of users, country of use, usage time and browser used, as well as the content that the visitor has visited. The cookie does not damage the drive.</p>\r\n\r\n<p>Cookies are used to speed up, analyze and develop the website and to target content to each user.</p>"
+    format: full_html

--- a/conf/cmi/language/fi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/language/fi/eu_cookie_compliance.settings.yml
@@ -6,5 +6,5 @@ popup_info:
   value: "<h2>Hel.fi käyttää evästeitä</h2><p>Tämä sivusto käyttää välttämättömiä evästeitä suorituskyvyn varmistamiseksi sekä yleisen käytön seurantaan. Lisäksi käytämme kohdennusevästeitä käyttäjäkokemuksen parantamiseksi, analytiikkaan ja kohdistetun sisällön näyttämiseen.</p>\r\n"
 disagree_button_label: 'Ei kiitos'
 withdraw_tab_button_label: Tietosuoja-asetukset
-save_preferences_button_label: 'Hyväksy valitut evästeet'
+save_preferences_button_label: 'Hyväksy vain välttämättömät evästeet'
 accept_all_categories_button_label: 'Hyväksy kaikki evästeet'

--- a/conf/cmi/language/fi/hdbt_admin_tools.cookie_consent_intro.yml
+++ b/conf/cmi/language/fi/hdbt_admin_tools.cookie_consent_intro.yml
@@ -1,5 +1,5 @@
 cc:
   content:
-    value: "<p>Eväste (engl. cookie) on pienikokoinen tekstitiedosto, jonka verkkoselain tallentaa käyttäjän tietokoneelle tai mobiililaitteelle, kun vierailet verkkosivustolla. Se ei vahingoita käyttäjän laitetta tai tiedostoja. Evästeitä ei voi käyttää haittaohjelmien levittämiseen.<br />\r\n<br />\r\nEvästeistä saatava käyttäjätieto auttaa meitä varmistamaan sivuston teknisen toimivuuden ja parantamaan digitaalisten palveluidemme laatua. Niiden avulla voimme kehittää sivuston käyttäjäystävällisyyttä ja helpottaa tiedon löytymistä.</p>\r\n"
     format: full_html
+    value: "<p>Eväste (engl. cookie) on pienikokoinen tekstitiedosto, jonka verkkoselain tallentaa käyttäjän tietokoneelle tai mobiililaitteelle, kun vierailet verkkosivustolla. Se ei vahingoita käyttäjän laitetta tai tiedostoja. Evästeitä ei voi käyttää haittaohjelmien levittämiseen.<br />\r\n<br />\r\nEvästeistä saatava käyttäjätieto auttaa meitä varmistamaan sivuston teknisen toimivuuden ja parantamaan digitaalisten palveluidemme laatua. Niiden avulla voimme kehittää sivuston käyttäjäystävällisyyttä ja helpottaa tiedon löytymistä.</p>\r\n"
   title: Evästeasetukset

--- a/conf/cmi/language/sv/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/language/sv/eu_cookie_compliance.settings.yml
@@ -7,5 +7,5 @@ popup_info:
 disagree_button_label: 'Nej, tack'
 withdraw_action_button_label: 'Återkalla samtycke'
 withdraw_tab_button_label: Sekretessinställningar
-save_preferences_button_label: 'Acceptera valda cookies'
+save_preferences_button_label: 'Acceptera endast nödvändiga cookies'
 accept_all_categories_button_label: 'Acceptera alla cookies'

--- a/conf/cmi/language/sv/hdbt_admin_tools.cookie_consent_intro.yml
+++ b/conf/cmi/language/sv/hdbt_admin_tools.cookie_consent_intro.yml
@@ -1,5 +1,5 @@
 cc:
-  title: 'Cookie -inställningar'
   content:
-    value: "<p>En kaka (eng. cookie) är en liten textfil som webbläsaren sparar i användarens dator eller mobila enhet när hen besöker en webbplats. Den skadar inte användarens enhet eller filer. Kakor kan inte användas för att sprida skadeprogram.<br />\r\n<br />\r\nAnvändarinformationen som fås från kakorna hjälper oss att säkerställa webbplatsens funktionalitet och förbättra kvaliteten på våra digitala tjänster. Med hjälp av dem kan vi utveckla webbplatsens användarvänlighet och göra det lättare att hitta information.</p>\r\n"
     format: full_html
+    value: "<p>En kaka (eng. cookie) är en liten textfil som webbläsaren sparar i användarens dator eller mobila enhet när hen besöker en webbplats. Den skadar inte användarens enhet eller filer. Kakor kan inte användas för att sprida skadeprogram.<br />\r\n<br />\r\nAnvändarinformationen som fås från kakorna hjälper oss att säkerställa webbplatsens funktionalitet och förbättra kvaliteten på våra digitala tjänster. Med hjälp av dem kan vi utveckla webbplatsens användarvänlighet och göra det lättare att hitta information.</p>\r\n"
+  title: 'Cookie -inställningar'


### PR DESCRIPTION
…ionality

# [LOM-269](https://helsinkisolutionoffice.atlassian.net/browse/LOM-269)

## What was done
<!-- Describe what was done -->

* Added missing translations and configuration to cookie banner functionality

## How to install

* Checkout the branch and run make commands.
  * `git checkout origin LOM-269_cookie_banner_settings`
  * `composer require drupal/helfi_platform_config:dev-UHF-X_add_missing_translation_for_cookie_banner`
  * `make shell`
  * `drush locale:check; drush locale:update; drush cr`
  * `exit`
  * `make drush-cim && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Remove cookies that you have accepted from your browser or open a browser where you haven't accepted any cookies from your local.
* [x] The cookie banner should appear on the bottom of the page. It should say the same text as in for example in https://www.hel.fi/fi/paatoksenteko-ja-hallinto on all three languages.
* [x] Click on the "Näytä evästeet/Show cookies" link and it should take you to cookie settings page. This page should also be fully translated and the texts should be the same as in here https://www.hel.fi/fi/paatoksenteko-ja-hallinto/evasteasetukset
* [x] Check the cookies that the site sets from developer tools from your browser and check that there isn't anything that is not listed in the "Näytä evästeet/Show cookies" page.
* [x] Also make sure that the site is not setting anything extra if you don't agree on any other cookies than the compulsory.
* [x] Check that code follows our standards