### PR TITLE
LOM-284 Hide form code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,9 @@
             "drupal/core": {
                 "Add ability to delete all from tempstore": "https://www.drupal.org/files/issues/2020-10-23/get_delete_all_temp-2475719-31.patch",
                 "Fix session cookie error": "https://www.drupal.org/files/issues/2021-12-22/3255711-invalidate_session_on_destroy_session_manager-4.patch"
+            },
+            "drupal/webform": {
+                "Support PHP 8.1 (https://www.drupal.org/node/3283614)": "https://git.drupalcode.org/project/webform/-/commit/9cd201a.patch"
             }
         }
     },

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -316,3 +316,44 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
     }
   }
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function form_tool_webform_parameters_form_node_form_alter(&$form, &$form_state, $form_id) {
+  if (!in_array($form_id, ['node_webform_edit_form', 'node_webform_form'])) {
+    return;
+  }
+
+  // Hide form code field from form.
+  $form['field_form_code']['#access'] = FALSE;
+
+  // Add validation callback for the handling of form code field.
+  array_unshift(
+    $form['#validate'],
+    'form_tool_webform_parameters_field_form_code_validate'
+  );
+}
+
+/**
+ * Validation function for the field form code field.
+ *
+ * @param array $form
+ *   Form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function form_tool_webform_parameters_field_form_code_validate(array &$form, FormStateInterface $form_state) {
+  $webform_id = $form_state->getValue('webform')[0]['target_id'];
+  $form_code = $form_state->getValue('field_form_code')[0]['value'];
+
+  if (empty($webform_id)) {
+    $form_state->unsetValue('field_form_code');
+  }
+  elseif ($webform_id !== $form_code) {
+    $form_state->setValue(
+      'field_form_code',
+      [['value' => $form_state->getValue('webform')[0]['target_id']]]
+    );
+  }
+}


### PR DESCRIPTION
# [LOM-284](https://helsinkisolutionoffice.atlassian.net/browse/LOM-284)

## What was done
- Added patch to fix compatibility issues with webform and php 8.1
- Added custom node form validation where the webform form code field can be populated based on chosen webform.

## How to install
- `git checkout LOM-284_hide_form_code`
- `composer install`
- `drush cr`

## How to test
- Go to add or edit a webform node type
  - Select webform and save the node
  - Check that the node gets url alias based on the selected webform
  - Check also translations
