### PR TITLE
LOM-269 Updated the incorrect text from cookie settings page

### DIFF
--- a/conf/cmi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/eu_cookie_compliance.settings.yml
@@ -65,7 +65,7 @@ withdraw_tab_button_label: 'Privacy settings'
 withdraw_action_button_label: 'Withdraw consent'
 withdraw_enabled: false
 withdraw_button_on_info_popup: false
-save_preferences_button_label: 'Accept only essential cookies'
+save_preferences_button_label: 'Accept selected cookies'
 accept_all_categories_button_label: 'Accept all cookies'
 enable_save_preferences_button: true
 domain_all_sites: true

--- a/conf/cmi/language/fi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/language/fi/eu_cookie_compliance.settings.yml
@@ -6,5 +6,5 @@ popup_info:
   value: "<h2>Hel.fi käyttää evästeitä</h2><p>Tämä sivusto käyttää välttämättömiä evästeitä suorituskyvyn varmistamiseksi sekä yleisen käytön seurantaan. Lisäksi käytämme kohdennusevästeitä käyttäjäkokemuksen parantamiseksi, analytiikkaan ja kohdistetun sisällön näyttämiseen.</p>\r\n"
 disagree_button_label: 'Ei kiitos'
 withdraw_tab_button_label: Tietosuoja-asetukset
-save_preferences_button_label: 'Hyväksy vain välttämättömät evästeet'
+save_preferences_button_label: 'Hyväksy valitut evästeet'
 accept_all_categories_button_label: 'Hyväksy kaikki evästeet'

--- a/conf/cmi/language/sv/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/language/sv/eu_cookie_compliance.settings.yml
@@ -7,5 +7,5 @@ popup_info:
 disagree_button_label: 'Nej, tack'
 withdraw_action_button_label: 'Återkalla samtycke'
 withdraw_tab_button_label: Sekretessinställningar
-save_preferences_button_label: 'Acceptera endast nödvändiga cookies'
+save_preferences_button_label: 'Acceptera valda cookies'
 accept_all_categories_button_label: 'Acceptera alla cookies'


### PR DESCRIPTION
# [LOM-269](https://helsinkisolutionoffice.atlassian.net/browse/LOM-269)

## What was done
<!-- Describe what was done -->

* Fixed button text on cookie information and settings page.

## How to install

* Checkout the branch and run make commands.
  * `git checkout origin LOM-269_updated_cookie_banner_settings`
  * `make drush-cim && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://hel-fi-form-tool.docker.so/en/forms/cookie-information-and-settings page and make sure that the button on the bottom of the page says 'Accept selected cookies' instead of 'Accept only essential cookies' on all three languages.
* [x] Check that code follows our standards

[LOM-269]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ