### PR TITLE
LOM-219: Login page, hide extra options from regular users

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -37,6 +37,7 @@ module:
   filter: 0
   focal_point: 0
   form_tool_contact_info: 0
+  form_tool_profile: 0
   form_tool_profile_data: 0
   form_tool_share: 0
   form_tool_webform_parameters: 0

--- a/public/modules/custom/form_tool_profile/form_tool_profile.info.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.info.yml
@@ -1,0 +1,8 @@
+name: 'Form tool profile'
+type: module
+description: 'Provide profile / user functionallity and helpers.'
+package: 'Helfi'
+version: 0.1
+core_version_requirement: ^8.8 || ^9
+dependencies:
+

--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Provides hooks and helpers for profile / user related things.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function form_tool_profile_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Hide fields from login forms without proper query strings.
+  // If we're at user login.
+  if ($form_id == 'user_login_form') {
+    $qParams = \Drupal::request()->query->all();
+    // We want to hide all normal login elements
+    // to only allow login via Tunnistamo.
+    if (!isset($qParams['login']) || $qParams['login'] != 'admin') {
+      unset($form['name']);
+      unset($form['pass']);
+      unset($form['actions']);
+    }
+  }
+  // And from Tunnistamo, we want to allow only user logins
+  // without loginparameter.
+  if ($form_id == 'openid_connect_login_form') {
+    $qParams = \Drupal::request()->query->all();
+
+    if (
+      !isset($qParams['login']) ||
+      !in_array($qParams['login'], ['admin', 'on-admin'])
+    ) {
+      unset($form["openid_connect_client_tunnistamoadmin_login"]);
+    }
+
+    // Show only TunnistamoAdmin login for this login parameter.
+    if (isset($qParams['login']) && $qParams['login'] === 'on-admin') {
+      unset($form["openid_connect_client_tunnistamo_login"]);
+    }
+  }
+
+}


### PR DESCRIPTION
# [LOM-219](https://helsinkisolutionoffice.atlassian.net/browse/LOM-219)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove extra login options from regular user
* Admin / On-Admin url parameter will showup extra logins as needed.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-219-form-permission`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ]  Open https://hel-fi-form-tool.docker.so/fi/lomakkeet/todistusjaljennospyynto-tilaus in private browser mode
* [ ]  Check that "Login with Tunnistamo" is the only login option
* [ ]  Add `?login=admin` to url - All login options should be visible
* [ ] Add `?login=on-admin` - Only "Login with TunnistamoAdmin" should be visible




[LOM-219]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ