### PR TITLE
LOM-267 Login page info 

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -2,3 +2,4 @@ _core:
   default_config_hash: QkouijUZWSmzRC1sUOJntoclIHqPYGTSt2534poifsQ
 ignored_config_entities:
   - 'hdbt_admin_tools.site_settings:site_settings'
+  - form_tool_profile.settings

--- a/conf/cmi/language/en/form_tool_profile.settings.yml
+++ b/conf/cmi/language/en/form_tool_profile.settings.yml
@@ -1,0 +1,3 @@
+login_info_no_auth: ""
+login_info_weak_auth: ""
+login_info_strong_auth: ""

--- a/conf/cmi/language/fi/form_tool_profile.settings.yml
+++ b/conf/cmi/language/fi/form_tool_profile.settings.yml
@@ -1,0 +1,3 @@
+login_info_no_auth: ""
+login_info_weak_auth: ""
+login_info_strong_auth: ""

--- a/conf/cmi/language/sv/form_tool_profile.settings.yml
+++ b/conf/cmi/language/sv/form_tool_profile.settings.yml
@@ -1,0 +1,3 @@
+login_info_no_auth: ""
+login_info_weak_auth: ""
+login_info_strong_auth: ""

--- a/public/modules/custom/form_tool_profile/config/install/form_tool_profile.settings.yml
+++ b/public/modules/custom/form_tool_profile/config/install/form_tool_profile.settings.yml
@@ -1,0 +1,4 @@
+login_info_no_auth: ''
+login_info_weak_auth: ''
+login_info_strong_auth: ''
+langcode: fi

--- a/public/modules/custom/form_tool_profile/config/schema/form_tool_profile.schema.yml
+++ b/public/modules/custom/form_tool_profile/config/schema/form_tool_profile.schema.yml
@@ -1,0 +1,13 @@
+form_tool_profile.settings:
+  type: config_object
+  label: 'Form tool profile settings'
+  mapping:
+    login_info_no_auth:
+      type: text
+      label: 'No authentication'
+    login_info_weak_auth:
+      type: text
+      label: 'Weak authentication'
+    login_info_strong_auth:
+      label: 'Strong authentication'
+      type: text

--- a/public/modules/custom/form_tool_profile/form_tool_profile.links.menu.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.links.menu.yml
@@ -1,0 +1,5 @@
+form_tool_profile.login_info:
+  title: 'Helfi: Login info configuration'
+  route_name: form_tool_profile.settings
+  menu_name: Hel.fi
+  parent: 'system.admin_config'

--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -43,3 +43,36 @@ function form_tool_profile_form_alter(&$form, FormStateInterface $form_state, $f
   }
 
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function form_tool_profile_preprocess_page(&$vars) {
+
+  // Webform access check - 403 Page.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $node = \Drupal::routeMatch()->getMasterRouteMatch()->getParameter('node');
+
+  if ($node && $node->getType() === 'webform' && $route_name === 'system.403') {
+    $webform_relation = $node->get('webform')->getValue()[0];
+    $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_relation['target_id']);
+
+    $login_type = $webform->getThirdPartySetting('form_tool_webform_parameters', 'login_type');
+
+    if ($login_type !== NULL) {
+      $info_text = \Drupal::service('form_tool_profile.login_info')->getLoginInfo($login_type);
+      $vars['page']['login_info'] = [
+        '#markup' => $info_text,
+      ];
+    }
+  }
+
+  // Check for basic user.login page.
+  if ($route_name === 'user.login') {
+    $info_text = \Drupal::service('form_tool_profile.login_info')->getLoginInfo();
+    $vars['page']['login_info'] = [
+      '#markup' => $info_text,
+    ];
+  }
+
+}

--- a/public/modules/custom/form_tool_profile/form_tool_profile.permissions.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.permissions.yml
@@ -1,0 +1,3 @@
+administer form_tool_profile configuration:
+  title: 'Administer form_tool_profile configuration'
+  restrict access: true

--- a/public/modules/custom/form_tool_profile/form_tool_profile.routing.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.routing.yml
@@ -1,0 +1,7 @@
+form_tool_profile.settings:
+  path: '/admin/config/form_tool_profile/settings'
+  defaults:
+    _form: '\Drupal\form_tool_profile\Form\ConfigForm'
+    _title: 'Form tool profile settings'
+  requirements:
+    _permission: 'administer form_tool_profile configuration'

--- a/public/modules/custom/form_tool_profile/form_tool_profile.services.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.services.yml
@@ -1,0 +1,4 @@
+services:
+  form_tool_profile.login_info:
+    class: Drupal\form_tool_profile\LoginInfoService
+    arguments: ['@language_manager', ]

--- a/public/modules/custom/form_tool_profile/form_tool_profle.config_translation.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profle.config_translation.yml
@@ -1,0 +1,5 @@
+form_tool_profile.settings:
+  title: 'Form tool profile configuration'
+  base_route_name: form_tool_profile.settings
+  names:
+    - 'form_tool_profile.settings'

--- a/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
+++ b/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
@@ -78,7 +78,7 @@ class ConfigForm extends ConfigFormBase {
 
     $form['login_info']['login_info_strong_auth'] = [
       '#type' => 'text_format',
-      '#title' => $this->t('Login info when the form requires weak authentication'),
+      '#title' => $this->t('Login info when the form requires strong authentication'),
       '#default_value' => $config->get('login_info_strong_auth'),
     ];
 

--- a/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
+++ b/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\form_tool_profile\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Config form for form_tool_profile module.
+ */
+class ConfigForm extends ConfigFormBase {
+
+  /**
+   * The language manager object.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(LanguageManagerInterface $language_manager) {
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'form_tool_profile.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'form_tool_profile_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    $language = $this->languageManager->getCurrentLanguage()->getId();
+    $config = $this->languageManager->getLanguageConfigOverride($language, 'form_tool_profile.settings');
+
+    $form['login_info'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Login info (@lang)', ['@lang' => $language]),
+    ];
+
+    $form['login_info']['login_info_no_auth'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Login info for login pagin'),
+      '#default_value' => $config->get('login_info_no_auth'),
+    ];
+
+    $form['login_info']['login_info_weak_auth'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Login info when the form requires weak authentication'),
+      '#default_value' => $config->get('login_info_weak_auth'),
+    ];
+
+    $form['login_info']['login_info_strong_auth'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Login info when the form requires weak authentication'),
+      '#default_value' => $config->get('login_info_strong_auth'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $language = $this->languageManager->getCurrentLanguage()->getId();
+
+    $this->languageManager->getLanguageConfigOverride($language, 'form_tool_profile.settings')
+      ->set('login_info_no_auth', $form_state->getValue('login_info_no_auth')['value'])
+      ->set('login_info_weak_auth', $form_state->getValue('login_info_weak_auth')['value'])
+      ->set('login_info_strong_auth', $form_state->getValue('login_info_strong_auth')['value'])
+      ->save();
+  }
+
+}

--- a/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
+++ b/public/modules/custom/form_tool_profile/src/Form/ConfigForm.php
@@ -66,7 +66,7 @@ class ConfigForm extends ConfigFormBase {
 
     $form['login_info']['login_info_no_auth'] = [
       '#type' => 'text_format',
-      '#title' => $this->t('Login info for login pagin'),
+      '#title' => $this->t('Login info for login page'),
       '#default_value' => $config->get('login_info_no_auth'),
     ];
 

--- a/public/modules/custom/form_tool_profile/src/LoginInfoService.php
+++ b/public/modules/custom/form_tool_profile/src/LoginInfoService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\form_tool_profile;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+
+/**
+ * Provides service that will get the login info for different login types.
+ */
+class LoginInfoService {
+
+  const AUTH_NONE   = 0;
+  const AUTH_WEAK   = 1;
+  const AUTH_STRONG = 2;
+
+  const CONFIG_MAPPING = [
+    self::AUTH_NONE   => 'login_info_no_auth',
+    self::AUTH_WEAK   => 'login_info_weak_auth',
+    self::AUTH_STRONG => 'login_info_strong_auth',
+  ];
+
+  /**
+   * The language manager object.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs LoginInfoService.
+   */
+  public function __construct(LanguageManagerInterface $language_manager) {
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * Gets login info text for given login type.
+   *
+   * @param int $loginType
+   *   Login type required by the webform.
+   *
+   * @return string|null
+   *   HTML string or NULL if no config was found for some reason.
+   */
+  public function getLoginInfo($loginType = 0) {
+    $loginType = intval($loginType);
+
+    $configuration_key = self::CONFIG_MAPPING[$loginType] ?? NULL;
+
+    if ($configuration_key) {
+      $language_id = $this->languageManager->getCurrentLanguage()->getId();
+      $config_value = $this->languageManager
+        ->getLanguageConfigOverride($language_id, 'form_tool_profile.settings')
+        ->get($configuration_key);
+
+      return $config_value;
+    }
+
+    return NULL;
+
+  }
+
+}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--401.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--401.html.twig
@@ -1,0 +1,46 @@
+{% embed 'page.html.twig' %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'error-page-content'} %}
+      {% block container_content %}
+        <div class="error-page__text-container">
+          <h1 class="error-page__title">{{ error_number|default('401') }} - {{ 'You do not have permission to access this page'|t }}</h1>
+          <p class="error-page__description">{{ 'This page is available to registered users only. If you have the necessary permissions, you can sign in to see the content.'|t }}</p>
+
+          {% set link_title %}
+            {{ 'Go back to the hel.fi homepage'|t({}, {'context': 'Return to homepage link for error pages'}) }}
+          {% endset %}
+          {% set link_attributes = {
+            'class': [
+              'error-page__link',
+            ],
+          } %}
+
+          <br>
+
+          {{ link(link_title, error_page_home_link, link_attributes) }}
+
+          <br>
+
+          {% set feedback_link_title %}
+            {{ 'Give feedback'|t({}, {'context': 'Feedback link for error pages'}) }}
+          {% endset %}
+          {{ link(feedback_link_title, error_page_feedback_link, link_attributes) }}
+
+          {% if user_not_logged_in %}
+            <h2 class="error-page__login-title">{{ 'Log in'|t({}, {'context': 'Log in block title on error pages'}) }}</h2>
+          {% endif %}
+          {{ page.login_info }}
+          <div class="error-page__login-form">
+            {{ drupal_block('user_login_block') }}
+          </div>
+        </div>
+        <div class="error-page__illustration-container">
+          <img src="/themes/contrib/hdbt/src/images/illustration_error_page_403_401.svg" alt="" class="error-page__illustration" width="379" height="566" />
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_content %}
+
+  {% block page_after_content %}
+  {% endblock page_after_content %}
+{% endembed %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--403.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--403.html.twig
@@ -1,0 +1,2 @@
+{% embed 'page--401.html.twig' with { error_number:'403' } %}
+{% endembed %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--user--login.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--user--login.html.twig
@@ -1,0 +1,21 @@
+{% embed 'page.html.twig' %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'user-login-page-content'} %}
+      {% block container_content %}
+        <div class="user-login__form-container">
+          <div class="user-login__text-container">
+            <h1 class="user-login-page__title">{{ 'Log in'|t }}</h1>
+            {{ page.login_info }}
+          </div>
+          {{ page.content|without(page_title_block) }}
+        </div>
+        <div class="user-login-page__illustration-container">
+          <img src="/themes/contrib/hdbt/src/images/illustration_user_login_page.svg" alt="" class="user-login-page__illustration"/>
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_content %}
+
+  {% block page_after_content %}
+  {% endblock page_after_content %}
+{% endembed %}


### PR DESCRIPTION
# [LOM-267](https://helsinkisolutionoffice.atlassian.net/browse/LOM-267)
<!-- What problem does this solve? -->

## What was done

* Configuration page where content editors / admins can change login instructions per webform login type.

This is done via configurations right now, as enabling translations for paragraphs caused some weird errors.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-267-login-page-info-blocks`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Check Configuration -> Helfi: Login info configuration (`/admin/config/form_tool_profile/settings`)
* [ ] Add text to different login types & translations
* [ ] Try to view webform as unauthenticated user.
* [ ] Try to view front page / login page - it should show non-authentication version
* [ ] Change or create webform with a weak authentication
* [ ] Language versions should work too, if the webform node has a translation available

webform:

![image](https://user-images.githubusercontent.com/43133397/212896963-a7babbd7-66dd-4688-9db8-a36d6cabcdf7.png)

login:
![image](https://user-images.githubusercontent.com/43133397/212897225-523978ff-e139-412b-bfec-2efc83d940d0.png)


[LOM-267]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ