### PR TITLE
LOM-273 Fixed one title on routing file and added translations

### DIFF
--- a/public/modules/custom/form_tool_share/form_tool_share.routing.yml
+++ b/public/modules/custom/form_tool_share/form_tool_share.routing.yml
@@ -66,7 +66,7 @@ form_tool_share.meta:
 form_tool_share.view_submission:
   path: '/lomake/{submission_id}'
   defaults:
-    _title: 'Lomakkeen tiedot'
+    _title: 'Form information'
     _controller: '\Drupal\form_tool_share\Controller\FormToolSubmissionController::build'
   requirements:
     _custom_access: '\Drupal\form_tool_share\Controller\FormToolSubmissionController::accessByApplicationNumber'

--- a/public/modules/custom/form_tool_share/translations/fi.po
+++ b/public/modules/custom/form_tool_share/translations/fi.po
@@ -17,3 +17,12 @@ msgstr "Kiitos"
 
 msgid "We will try to process your submission as quickly as possible."
 msgstr "Yritämme käsitellä lähettämäsi vastauksen mahdollisimman pian."
+
+msgid "Form submitted successfully"
+msgstr "Lomake lähetettiin onnistuneesti"
+
+msgid "Submit error"
+msgstr "Lähetysvirhe"
+
+msgid "Form information"
+msgstr "Lomakkeen tiedot"

--- a/public/modules/custom/form_tool_share/translations/sv.po
+++ b/public/modules/custom/form_tool_share/translations/sv.po
@@ -17,3 +17,12 @@ msgstr "Tack"
 
 msgid "We will try to process your submission as quickly as possible."
 msgstr "Vi kommer att försöka behandla din inlämning så snabbt som möjligt."
+
+msgid "Form submitted successfully"
+msgstr "Formuläret har skickats"
+
+msgid "Submit error"
+msgstr "Skicka fel"
+
+msgid "Form information"
+msgstr "Forminformation"


### PR DESCRIPTION
# [LOM-273](https://helsinkisolutionoffice.atlassian.net/browse/LOM-273)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed one titles language on routing file.
* Added missing translations.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-273_missing_translations
  * `make drush-cim && make drush-cr`
  * `make shell`
  * `drush locale:check; drush locale:update; drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the titles in the form process are translated to Finnish when using the Finnish side of the site.
* [ ] Check that code follows our standards

[LOM-273]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ