### PR TITLE
LOM-184: Hallinnoija access check hardening 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "drupal/twig_debugger": "^1.1",
         "drupal/webform": "^6.0",
         "drupal/webform_rest": "^4.0",
+        "drupal/webform_translation_permissions": "^1.1",
         "drupal/x_frame_options_configuration": "^1.2",
         "drush/drush": "^10.4",
         "firebase/php-jwt": "^6.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b6efeb38d9bd894ed2f0f6f75186ecb",
+    "content-hash": "17afd549b38c849792f9c339a5afbdf8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7985,6 +7985,58 @@
             "homepage": "https://www.drupal.org/project/webform_rest",
             "support": {
                 "source": "https://git.drupalcode.org/project/webform_rest"
+            }
+        },
+        {
+            "name": "drupal/webform_translation_permissions",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/webform_translation_permissions.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/webform_translation_permissions-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "578e1a5cd07e0fb4ea1b59f1c9537e231b641692"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/webform": "^5.15 || ^6.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1603500607",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Holmes",
+                    "homepage": "https://www.drupal.org/u/rob-holmes",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Stefanos Petrakis",
+                    "homepage": "https://www.drupal.org/u/stefanospetrakis",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Granular permissions to translate webforms.",
+            "homepage": "https://drupal.org/project/webform_translation_permissions",
+            "support": {
+                "source": "http://cgit.drupalcode.org/webform_translation_permissions",
+                "issues": "https://www.drupal.org/project/issues/webform_translation_permissions?version=8.x"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -137,6 +137,7 @@ module:
   webform_rest: 0
   webform_share: 0
   webform_templates: 0
+  webform_translation_permissions: 0
   webform_ui: 0
   pathauto: 1
   content_translation: 10

--- a/conf/cmi/user.role.verkkolomake_admin.yml
+++ b/conf/cmi/user.role.verkkolomake_admin.yml
@@ -7,6 +7,7 @@ dependencies:
   module:
     - content_translation
     - node
+    - role_delegation
     - scheduler
     - system
     - toolbar
@@ -14,6 +15,7 @@ dependencies:
     - webform
     - webform_node
     - webform_templates
+    - webform_translation_permissions
 id: verkkolomake_admin
 label: Verkkolomake-admin
 weight: 0
@@ -64,6 +66,8 @@ permissions:
   - 'edit webform variants'
   - 'revert webform revisions'
   - 'schedule publishing of nodes'
+  - 'translate any webform'
+  - 'translate own webform'
   - 'translate webform node'
   - 'view any unpublished webform content'
   - 'view any webform submission'

--- a/conf/cmi/user.role.verkkolomake_hallinnoija.yml
+++ b/conf/cmi/user.role.verkkolomake_hallinnoija.yml
@@ -14,6 +14,7 @@ dependencies:
     - toolbar
     - webform
     - webform_node
+    - webform_translation_permissions
 id: verkkolomake_hallinnoija
 label: Verkkolomake-hallinnoija
 weight: -1
@@ -43,6 +44,7 @@ permissions:
   - 'edit own webform submission'
   - 'revert webform revisions'
   - 'schedule publishing of nodes'
+  - 'translate own webform'
   - 'translate webform node'
   - 'view own unpublished content'
   - 'view own webform submission'

--- a/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -173,6 +173,8 @@ settings:
   wizard_toggle: false
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''
@@ -191,7 +193,7 @@ settings:
   confirmation_type: page
   confirmation_url: ''
   confirmation_title: 'Todistusjäljennöspyyntö lähetetty'
-  confirmation_message: "T&auml;h&auml;n voidaan kirjoittaa asiakkaalle relevanttia tietoa lomakkeen k&auml;sittelyst&auml;.<br />\r\n<br />\r\n<strong>Lorem Ipsum</strong>&nbsp;is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry&#39;s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+  confirmation_message: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/public/modules/custom/form_tool_return_link/src/Plugin/Block/ReturnLinkBlock.php
+++ b/public/modules/custom/form_tool_return_link/src/Plugin/Block/ReturnLinkBlock.php
@@ -42,6 +42,9 @@ class ReturnLinkBlock extends BlockBase {
       $returnLinkText = $serviceDetailsLinkText;
       $returnLinkUrl = \Drupal::state()->get(\Drupal::request()->get('backlink_id'));
     }
+    else {
+      return [];
+    }
 
     // Webform node page.
     if (array_key_exists('node', $params)) {

--- a/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
+++ b/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\user\Entity\Role;
 use Drupal\webform\Entity\Webform;
 
@@ -341,5 +342,66 @@ function webform_formtool_handler_node_access(EntityInterface $entity, string $o
     $operation == 'view' &&
     $account->isAnonymous()) {
     return AccessResult::forbidden('Anonymous access denied to webform ');
+  }
+
+  // LomakeHallinoija checks for editing webform page. Short circuit missing
+  // verkkolomake_hallinnoija role - so we won't do unneccesary heavy lifting.
+  if (
+    in_array('verkkolomake_hallinnoija', $account->getRoles()) &&
+    $entity->getType() == 'webform' &&
+    in_array($operation, ['update', 'delete']) &&
+    !$account->isAnonymous()
+  ) {
+
+    $webform_relation = reset($entity->get('webform')->getValue());
+
+    if (empty($webform_relation)) {
+      return AccessResult::neutral();
+    }
+
+    $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_relation['target_id']) ?? NULL;
+
+    if (!$webform) {
+      return AccessResult::neutral();
+    }
+
+    $owner_id = $webform->getOwner()->id();
+    $account_id = $account->id();
+    if ($owner_id !== $account_id) {
+      return AccessResult::forbidden();
+    }
+  }
+
+}
+
+/**
+ * Implements hook_options_list_alter().
+ */
+function webform_formtool_handler_options_list_alter(array &$options, array $context) {
+
+  // Add new webform node - Webform selection dropdown.
+  if (
+    isset($context['fieldDefinition']) &&
+    $context['fieldDefinition'] instanceof FieldConfig &&
+    $context['fieldDefinition']->id() === 'node.webform.webform'
+  ) {
+    $user = \Drupal::currentUser();
+    $roles = $user->getRoles();
+
+    // VerkkolomakeAdmin and uid 1 has always all options.
+    if (array_intersect($roles, ['admin', 'verkkolomake_admin']) || $user->id() == 1) {
+      return;
+    }
+
+    static $webform_ids;
+
+    if (!isset($webform_ids)) {
+      // Get webforms with same owner as current uid.
+      $webform_ids = \Drupal::entityQuery('webform')
+        ->condition('uid', $user->id())
+        ->execute();
+    }
+
+    $options = array_intersect_key($webform_ids, $options);
   }
 }

--- a/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
+++ b/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
@@ -90,6 +90,12 @@ function webform_formtool_handler_webform_presave(Webform $entity) {
     $config->set('roles', $allRoles);
     $config->save();
 
+    // Grant roleassign permission to admin role.
+    $roleString = "assign $roleMachineName role";
+    $verkkolomakeAdminRole = Role::load('verkkolomake_admin');
+    $verkkolomakeAdminRole->grantPermission($roleString);
+    $verkkolomakeAdminRole->save();
+
   }
   // If this role has not yet been added to 3rd party settings, do it now.
   if (!in_array($roleMachineName, $thirdPartySettings['roles'])) {


### PR DESCRIPTION
# [LOM-184](https://helsinkisolutionoffice.atlassian.net/browse/LOM-184)

## What was done

* Checked permissions and hardened access check a little bit for VerkkolomakeHallinoija role.
* Installed webform_translate_permissions, as webform translations by default requires 'translate configuration', which is kinda broad permission to give.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-184-permission-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Login as VerkkolomakeHallinoija. Create few test webforms with this user. https://hel-fi-form-tool.docker.so/en/forms/admin/structure/webform
* Create webform nodes for these https://hel-fi-form-tool.docker.so/en/forms/admin/content
* When creating a node - Webform dropdown selection should only show forms that the user has ownership of.
* On content listing, VerkkolomakeHallinoija should only to be able edit/delete webform nodes, where the linked is webform is on their ownership
* Both VerkkolomakeHallinoija and VerkkolomakeAdmin should now be able to translate webforms (https://hel-fi-form-tool.docker.so/en/forms/admin/structure/webform)


[LOM-184]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ