### PR TITLE
Feature/lom 323 403 cache issue

### DIFF
--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -11,7 +11,6 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_form_alter().
  */
 function form_tool_profile_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
   // Hide fields from login forms without proper query strings.
   // If we're at user login.
   if ($form_id == 'user_login_form') {

--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -54,6 +54,12 @@ function form_tool_profile_preprocess_page(&$vars) {
   $node = \Drupal::routeMatch()->getMasterRouteMatch()->getParameter('node');
 
   if ($node && $node->getType() === 'webform' && $route_name === 'system.403') {
+
+    if (\Drupal::request()->attributes->has('exception')) {
+      $vars['#cache']['max-age'] = 0;
+      \Drupal::service('page_cache_kill_switch')->trigger();
+    }
+
     $webform_relation = $node->get('webform')->getValue()[0];
     $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_relation['target_id']);
 

--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -23,6 +23,15 @@ function form_tool_profile_form_alter(&$form, FormStateInterface $form_state, $f
       unset($form['pass']);
       unset($form['actions']);
     }
+
+    // Let's not cache this form at all, anywhere.
+    // Or cache it per url query args.
+    $form['#cache'] = [
+      'contexts' => [
+        'url.query_args',
+      ],
+    ];
+
   }
   // And from Tunnistamo, we want to allow only user logins
   // without loginparameter.

--- a/public/modules/custom/form_tool_webform_parameters/translations/fi/fi.po
+++ b/public/modules/custom/form_tool_webform_parameters/translations/fi/fi.po
@@ -43,7 +43,7 @@ msgstr "Vahva tunnistautuminen"
 msgid "Postal address for paper form delivery"
 msgstr "Lomakkeen paperiversion toimitusosoite"
 
-msgid "Read more about <a href="@privacy-policy-link">the privacy policy</a> (the link will open in a new tab)."
+msgid "Read more about <a href=\"@privacy-policy-link\">the privacy policy</a> (the link will open in a new tab)."
 msgstr "Lue lisää <a href=\"@privacy-policy-link\">rekisteriselosteesta</a> (linkki avautuu uuteen välilehteen)."
 
 msgid "Privacy Policy"

--- a/public/modules/custom/form_tool_webform_parameters/translations/sv/sv.po
+++ b/public/modules/custom/form_tool_webform_parameters/translations/sv/sv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 
 
-msgid "Read more about <a href="@privacy-policy-link">the privacy policy</a> (the link will open in a new tab)."
+msgid "Read more about <a href=\"@privacy-policy-link\">the privacy policy</a> (the link will open in a new tab)."
 msgstr "Läs mer om <a href=\"@privacy-policy-link\">registerbeskrivningen</a> (länken öppnas i en ny flik)."
 
 msgid "Privacy Policy"


### PR DESCRIPTION
# [LOM-323](https://helsinkisolutionoffice.atlassian.net/browse/LOM-323)
<!-- What problem does this solve? -->

403 pages were cached and this was an issue with custmoized forms.

## What was done
<!-- Describe what was done -->

* Added cache context for login form.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

You can test this at https://www.hel.fi/fi/dev-lomakkeet no need to build locally this small change. This branch is deployed there.

* [ ] Go to https://www.hel.fi/fi/dev-lomakkeet/todistusjaljennospyynto-tilaus 
* [ ] Go to https://www.hel.fi/fi/dev-lomakkeet/todistusjaljennospyynto-tilaus?login=admin
* [ ] See that login forms differ.



[LOM-323]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ