### PR TITLE
LOM-154: Add endpoints for probe checks.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4907,12 +4907,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili.git",
-                "reference": "135f639123c9c438741cbb8bef96c1e83bf1c5b5"
+                "reference": "fa42f454999838ce4983b35a4e834c1730254029"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/zipball/135f639123c9c438741cbb8bef96c1e83bf1c5b5",
-                "reference": "135f639123c9c438741cbb8bef96c1e83bf1c5b5",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/zipball/fa42f454999838ce4983b35a4e834c1730254029",
+                "reference": "fa42f454999838ce4983b35a4e834c1730254029",
                 "shasum": ""
             },
             "require": {
@@ -4940,7 +4940,7 @@
                 "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/tree/develop",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/issues"
             },
-            "time": "2023-01-04T06:34:38+00:00"
+            "time": "2023-01-19T09:02:49+00:00"
         },
         {
             "name": "drupal/helfi_media_formtool",

--- a/public/modules/custom/form_tool_profile/form_tool_profile.routing.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.routing.yml
@@ -5,3 +5,19 @@ form_tool_profile.settings:
     _title: 'Form tool profile settings'
   requirements:
     _permission: 'administer form_tool_profile configuration'
+
+form_tool_profile.readiness:
+  path: '/readiness'
+  defaults:
+    _title: 'Readiness'
+    _controller: '\Drupal\form_tool_profile\Controller\FormToolProbeController::readiness'
+  requirements:
+    _access: 'TRUE'
+
+form_tool_profile.healthz:
+  path: '/healthz'
+  defaults:
+    _title: 'Healthz'
+    _controller: '\Drupal\form_tool_profile\Controller\FormToolProbeController::healthz'
+  requirements:
+    _access: 'TRUE'

--- a/public/modules/custom/form_tool_profile/src/Controller/FormToolProbeController.php
+++ b/public/modules/custom/form_tool_profile/src/Controller/FormToolProbeController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\form_tool_profile\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Returns responses for Form tool profile routes.
+ */
+class FormToolProbeController extends ControllerBase {
+
+  /**
+   * Response to readiness probe.
+   */
+  public function readiness(): JsonResponse {
+    return new JsonResponse(['data' => [], 'method' => 'GET', 'status' => 200]);
+  }
+
+  /**
+   * Response to healthz probe.
+   */
+  public function healthz(): JsonResponse {
+    return new JsonResponse(['data' => [], 'method' => 'GET', 'status' => 200]);
+  }
+
+}


### PR DESCRIPTION
# [PROC-2724](https://helsinkisolutionoffice.atlassian.net/browse/PROC-2724)
<!-- What problem does this solve? -->

Per requirements applications must implement readiness & healthz probes. This creates those.

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-154-probes`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://hel-fi-form-tool.docker.so/healthz
* [ ] Go to https://hel-fi-form-tool.docker.so/readiness
* [ ] See that those respond with 200 status.



[PROC-2724]: https://helsinkisolutionoffice.atlassian.net/browse/PROC-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ