### PR TITLE
Feature/lom 277 logout redirection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,9 @@
             "drupal/core": {
                 "Add ability to delete all from tempstore": "https://www.drupal.org/files/issues/2020-10-23/get_delete_all_temp-2475719-31.patch",
                 "Fix session cookie error": "https://www.drupal.org/files/issues/2021-12-22/3255711-invalidate_session_on_destroy_session_manager-4.patch"
+            },
+            "drupal/openid_connect": {
+                "Open Id connect patch": "public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch"
             }
         }
     },

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -92,6 +92,7 @@ module:
   node: 0
   oembed_providers: 0
   openid_connect: 0
+  openid_logout_redirect: 0
   options: 0
   page_cache: 0
   paragraphs_asymmetric_translation_widgets: 0

--- a/public/modules/custom/form_tool_profile/js/dialog.js
+++ b/public/modules/custom/form_tool_profile/js/dialog.js
@@ -1,5 +1,20 @@
 (function ($, Drupal, drupalSettings) {
+
   Drupal.theme.formTooldialog = function (options) {
+
+    function getTargetLink() {
+
+      var internal = drupalSettings.form_tool_profile.basePaths.some(function (url) {
+        return options.iniatorElement.href.includes(url);
+      });
+
+      if (internal) {
+        return options.iniatorElement.href;
+      }
+
+      return options.logoutLink + '&dest=' + options.iniatorElement.href;
+    }
+
     var element = $('<div class="dialog__container">' +
       '<div class="dialog__content">' +
         '<div class="dialog__header">' +
@@ -7,7 +22,7 @@
           '<h2 tabindex="-1"><span aria-hidden="true" class="hel-icon hel-icon--info-circle hel-icon--size-l"></span> '+ options.headerText +'</h2></div>' +
         '<div class="dialog__body"><p>' + options.bodyText + '</p></div>' +
         '<div class="dialog__actions">' +
-          '<a href="' + options.logoutLink + '" class="hds-button hds-button--primary">' +
+          '<a href="' + getTargetLink() + '" class="hds-button hds-button--primary">' +
             '<span class="hds-button__label">'+options.logoutBtnText+'</span>' +
           '</a>' +
           '<button type="button" class="hds-button hds-button--secondary dialog__close-button">' +

--- a/public/modules/custom/helfi_gdpr_api/helfi_gdpr_api.routing.yml
+++ b/public/modules/custom/helfi_gdpr_api/helfi_gdpr_api.routing.yml
@@ -15,3 +15,12 @@ helfi_gdpr_api.endpoint_delete:
     _controller: '\Drupal\helfi_gdpr_api\Controller\HelfiGdprApiController::delete'
   requirements:
     _custom_access: '\Drupal\helfi_gdpr_api\Controller\HelfiGdprApiController::access'
+
+helfi_gdpr_api.testaatk:
+  path: '/helfi-gdpr-api/testaatk'
+  methods: ['POST']
+  defaults:
+    _title: 'Example'
+    _controller: '\Drupal\helfi_gdpr_api\Controller\TestaaTkApiController::build'
+  requirements:
+    _access: 'TRUE'

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/TestaaTkApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/TestaaTkApiController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\helfi_gdpr_api\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Returns responses for helfi_gdpr_api routes.
+ */
+class TestaaTkApiController extends ControllerBase {
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * RedirectService constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   Request stack.
+   */
+  public function __construct(
+    RequestStack $request_stack,
+  ) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack'),
+    );
+  }
+
+  /**
+   * Builds the response.
+   */
+  public function build() {
+
+    $foo = $this->requestStack->getCurrentRequest()->get('data');
+
+    $response = new Response();
+    $response->setContent($foo);
+    $response->headers->set('Content-Type', 'text/xml');
+
+    return $response;
+
+  }
+
+}

--- a/public/modules/custom/openid_logout_redirect/openid_logout_redirect.info.yml
+++ b/public/modules/custom/openid_logout_redirect/openid_logout_redirect.info.yml
@@ -1,0 +1,8 @@
+name: openid_logout_redirect
+type: module
+description: Implement oidc logout redirection
+package: Helfi
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+  - openid_connect

--- a/public/modules/custom/openid_logout_redirect/openid_logout_redirect.routing.yml
+++ b/public/modules/custom/openid_logout_redirect/openid_logout_redirect.routing.yml
@@ -1,0 +1,9 @@
+openid_logout_redirect:
+  path: '/logout/redirect'
+  defaults:
+    _title: Redirection page
+    _controller: '\Drupal\openid_logout_redirect\Controller\OpenIDConnectLogoutRedirectController::logoutRedirect'
+  requirements:
+    _access: 'TRUE'
+  arguments:
+   - '@session'

--- a/public/modules/custom/openid_logout_redirect/openid_logout_redirect.services.yml
+++ b/public/modules/custom/openid_logout_redirect/openid_logout_redirect.services.yml
@@ -3,3 +3,5 @@ services:
     class: 'Drupal\openid_logout_redirect\Service\RedirectService'
     arguments:
       - '@request_stack'
+      - '@language_manager'
+      - '@module_handler'

--- a/public/modules/custom/openid_logout_redirect/openid_logout_redirect.services.yml
+++ b/public/modules/custom/openid_logout_redirect/openid_logout_redirect.services.yml
@@ -1,0 +1,5 @@
+services:
+  openid_logout_redirect.redirect:
+    class: 'Drupal\openid_logout_redirect\Service\RedirectService'
+    arguments:
+      - '@request_stack'

--- a/public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch
+++ b/public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch
@@ -11,7 +11,7 @@ index 3f724e4..d2dc8cf 100644
 +    try {
 +      $redirect_service = \Drupal::service('openid_logout_redirect.redirect');
 +      if ($redirect_service) {
-+        $redirect_service->setLogoutRedirectUrl('https://hel.fi/fi', $response);
++        $redirect_service->setLogoutRedirectUrl($response);
 +      }
 +    } catch (\Exception $e) {}
 +

--- a/public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch
+++ b/public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Controller/OpenIDConnectRedirectController.php b/src/Controller/OpenIDConnectRedirectController.php
+index 3f724e4..d2dc8cf 100644
+--- a/src/Controller/OpenIDConnectRedirectController.php
++++ b/src/Controller/OpenIDConnectRedirectController.php
+@@ -468,6 +468,15 @@ class OpenIDConnectRedirectController implements ContainerInjectionInterface, Ac
+     }
+     // Logout from Drupal.
+     user_logout();
++
++    // Patched for logout redirection.
++    try {
++      $redirect_service = \Drupal::service('openid_logout_redirect.redirect');
++      if ($redirect_service) {
++        $redirect_service->setLogoutRedirectUrl('https://hel.fi/fi', $response);
++      }
++    } catch (\Exception $e) {}
++
+     return $response;
+   }
+

--- a/public/modules/custom/openid_logout_redirect/src/Controller/OpenIDConnectLogoutRedirectController.php
+++ b/public/modules/custom/openid_logout_redirect/src/Controller/OpenIDConnectLogoutRedirectController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\openid_logout_redirect\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\openid_logout_redirect\Service\RedirectService;
+
+/**
+ * Redirect controller class.
+ */
+class OpenIDConnectLogoutRedirectController extends ControllerBase implements ContainerInjectionInterface {
+
+  /**
+   * The session object.
+   *
+   * @var Drupal\openid_logout_redirect\Service\RedirectService
+   */
+  protected $redirect;
+
+  /**
+   * OpenIDConnectLogoutRedirectController constructor.
+   *
+   * @param Drupal\openid_logout_redirect\Service\RedirectService $redirectService
+   *   The redirect service.
+   */
+  public function __construct(RedirectService $redirectService) {
+    $this->redirect = $redirectService;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('openid_logout_redirect.redirect'),
+    );
+  }
+
+  /**
+   * User logout redirection.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   Redirect response.
+   */
+  public function logoutRedirect() {
+    return $this->redirect->getLogoutRedirectUrl();
+  }
+
+}

--- a/public/modules/custom/openid_logout_redirect/src/Service/RedirectService.php
+++ b/public/modules/custom/openid_logout_redirect/src/Service/RedirectService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\openid_logout_redirect\Service;
+
+use Drupal\Core\Http\RequestStack;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * RedirectService to handle saving and retriving logout redirection.
+ */
+class RedirectService {
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * RedirectService constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   Request stack.
+   */
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * Sets logout url to cookie.
+   *
+   * @param string $url
+   *   Url.
+   * @param \Symfony\Component\HttpFoundation\Response $response
+   *   Response.
+   */
+  public function setLogoutRedirectUrl(string $url, Response $response) {
+
+    if (empty($url)) {
+      return;
+    }
+
+    $cookie = new Cookie('logout_redirect_url', $url);
+    $response->headers->setCookie($cookie);
+
+  }
+
+  /**
+   * Gets logout url from cookie.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   Redirect response.
+   */
+  public function getLogoutRedirectUrl() {
+    $url = $this->requestStack->getCurrentRequest()->cookies->get('logout_redirect_url');
+
+    if (empty($url)) {
+      $url = 'https://hel.fi/fi';
+    }
+
+    $response = new TrustedRedirectResponse($url);
+    $response->headers->clearCookie('logout_redirect_url');
+    return $response;
+  }
+
+}

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -15,3 +15,6 @@ msgstr "Nedan finns uppgifterna för ett inlämnat formulär."
 msgctxt "Log in block title on error pages"
 msgid "Login to the form"
 msgstr "Logga in i formuläret"
+
+msgid "Below is the data of a submitted form."
+msgstr "Nedan finns uppgifterna för ett inlämnat formulär."


### PR DESCRIPTION
# [LOM-277](https://helsinkisolutionoffice.atlassian.net/browse/LOM-277)

## What was done

* Patch to openid_connect module to use our service
* Logout will now redirect to external website.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-277-logout-redirection`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure the patch is applied after make fresh
* [ ] Login as normal user and trigger logout via clicking external link etc.
* [ ] After tunnistamo / helsinki profiili session end visit: https://hel-fi-form-tool.docker.so/fi/lomakkeet/logout/redirect to manually test return url


[LOM-277]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ