### PR TITLE
LOM-344: fix typo in postal address

### DIFF
--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -78,7 +78,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
       $webform = Webform::load($form['#webform_id']);
       $formsettings = $webform->getThirdPartySettings('form_tool_webform_parameters');
 
-      $privacy_policy_string = t('<a href="@privacy-policy-link" target="_blank">Read the privacy policy here</a> (the link will open in a new tab).', [
+      $privacy_policy_string = t('Read more about <a href="@privacy-policy-link" class="privacy-policy-link" target="_blank">the privacy policy</a> (the link will open in a new tab).', [
         '@privacy-policy-link' => _form_tool_webform_parameters_get_default_privacy_policy_link($formsettings),
       ]);
       $form['privacy_policy_wrapper'] = [
@@ -253,7 +253,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
     $form['third_party_settings']['form_tool_webform_parameters']['postal_address'] = [
       '#type' => 'textarea',
       '#title' => t('Postal address for paper form delivery'),
-      '#default_value' => $bundle->getThirdPartySetting('form_tool_webform_parameters', 'postal_adress'),
+      '#default_value' => $bundle->getThirdPartySetting('form_tool_webform_parameters', 'postal_address'),
       '#required' => FALSE,
     ];
 


### PR DESCRIPTION
# [LOM-344](https://helsinkisolutionoffice.atlassian.net/browse/LOM-344)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed typo in postal address in third party settings

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-344-asetukset-toimitusosoite`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Navigate to Todistusjäljennöspyynto tilaus -form in admin
* [ ] Go to settings and scroll down to Lomakkeen esitiedot
* [ ] Write something to Lomakkeen paperiversion toimitusosoite -field and save. Check that the text is still there after saving.


[LOM-344]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ