### PR TITLE
LOM-353: Editable entity translation permissions

### DIFF
--- a/conf/cmi/user.role.verkkolomake_admin.yml
+++ b/conf/cmi/user.role.verkkolomake_admin.yml
@@ -67,6 +67,7 @@ permissions:
   - 'revert webform revisions'
   - 'schedule publishing of nodes'
   - 'translate any webform'
+  - 'translate editable entities'
   - 'translate own webform'
   - 'translate webform node'
   - 'view any unpublished webform content'

--- a/conf/cmi/user.role.verkkolomake_hallinnoija.yml
+++ b/conf/cmi/user.role.verkkolomake_hallinnoija.yml
@@ -44,6 +44,7 @@ permissions:
   - 'edit own webform submission'
   - 'revert webform revisions'
   - 'schedule publishing of nodes'
+  - 'translate editable entities'
   - 'translate own webform'
   - 'translate webform node'
   - 'view own unpublished content'


### PR DESCRIPTION
# [LOM-353](https://helsinkisolutionoffice.atlassian.net/browse/LOM-353)

## What was done

Added permission to VerkkolomakeAdmin & VerkkolomakeHallinoija to add / edit webform node translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-353-webform-content-node-translate-perms`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that VerkkolomakeHallinoija & Admin can make translations for the webform nodes
* [ ]Hallinoija should only be to able make translations for their own content.



[LOM-353]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ