### PR TITLE
LOM-359: Remove gdpr from config, and make it use env variables.

### DIFF
--- a/public/modules/custom/helfi_gdpr_api/config/install/helfi_gdpr_api.settings.yml
+++ b/public/modules/custom/helfi_gdpr_api/config/install/helfi_gdpr_api.settings.yml
@@ -1,4 +1,0 @@
-audience_config:
-  audience_host: 'https://api.hel.fi/auth'
-  service_name: lomaketyokalugdprapi
-

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -144,10 +144,10 @@ class HelfiGdprApiController extends ControllerBase {
     $this->currentLanguageContext = $currentLanguageContext;
     $this->connection = $connection;
 
-    $this->audienceConfig = $this->config('helfi_gdpr_api.settings')
-      ->get('audience_config');
-
-    $this->audienceConfig['service_name'] = $this->audienceConfig['service_name'] . strtolower(getenv('APP_ENV'));
+    $this->audienceConfig = [
+      'service_name' => getenv('GDPR_API_AUD_SERVICE'),
+      'audience_host' => getenv('GDPR_API_AUD_HOST'),
+    ];
 
     $this->setDebug(getenv('DEBUG') == 'true' || getenv('DEBUG') == TRUE);
     $this->parseJwt();


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

Fix access denied errors that were due to incorrect handling of configured values vs env names.

## What was done
<!-- Describe what was done -->

* Add GDPR_API_AUD_HOST & GDPR_API_AUD_SERVICE environment variables.

@Krisseck these will need to be updated to standalone gdpr api module. Sorry about this.