### PR TITLE
LOM-348: helsinkiprofiili-linkki

### DIFF
--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
@@ -275,6 +275,7 @@ class FormToolProfileData extends WebformCompositeBase {
       'editLink' => [
         '#type' => 'link',
         '#url' => $profileEditUrl,
+        '#attributes' => ['target' => '_blank'],
         '#title' => t('Go to Helsinki-profile to edit your information.'),
         '#suffix' => '('.t('the link opens in a new tab').')',
       ],

--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
@@ -252,7 +252,7 @@ class FormToolProfileData extends WebformCompositeBase {
       ];
     }
 
-    $profileEditUrl = Url::fromUri('https://suomi.fi');
+    $profileEditUrl = Url::fromUri(getenv('HELSINKI_PROFIILI_URI'));
     $profileEditUrl->mergeOptions([
       'attributes' => [
         'title' => t('If you want to change the information from Helsinki-profile you can do that by going to the Helsinki-profile from this link.'),
@@ -276,6 +276,7 @@ class FormToolProfileData extends WebformCompositeBase {
         '#type' => 'link',
         '#url' => $profileEditUrl,
         '#title' => t('Go to Helsinki-profile to edit your information.'),
+        '#suffix' => '('.t('the link opens in a new tab').')',
       ],
       'refreshLink' => [
         '#type' => 'link',

--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/translations/fi/fi.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/translations/fi/fi.po
@@ -43,3 +43,7 @@ msgstr "Jos haluat muuttaa tietoja, jotka on haettu Helsinki-profiilista voit te
 
 msgid "If the data from Helsinki-profile is old you can refresh the data by pressing this link."
 msgstr "Jos Helsinki-profiilista haetut tiedot ovat vanhentuneet voit päivittää ne painamalla tätä linkkiä."
+
+msgctxt "Explanation for users that the link opens in a new tab instead of the expected current tab"
+msgid "The link opens in a new tab"
+msgstr "Linkki avautuu uuteen välilehteen"

--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/translations/sv/sv.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/translations/sv/sv.po
@@ -43,3 +43,7 @@ msgstr "Om du vill ändra informationen från Helsingfors-profilen kan du göra 
 
 msgid "If the data from Helsinki-profile is old you can refresh the data by pressing this link."
 msgstr "Om uppgifterna från Helsingfors-profilen är gamla kan du uppdatera uppgifterna genom att klicka på denna länk."
+
+msgctxt "Explanation for users that the link opens in a new tab instead of the expected current tab"
+msgid "The link opens in a new tab"
+msgstr "Länken öppnas i en ny flik"


### PR DESCRIPTION
# [LOM-348](https://helsinkisolutionoffice.atlassian.net/browse/LOM-348)
<!-- What problem does this solve? -->

## What was done

* Helsinki-profiili now directs to the correct place

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`
* Add a line to your local settings: `putenv('HELSINKI_PROFIILI_URI=https://profiili.test.hel.ninja/login');`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to the form. click on the 'siirry helsinki-profiiliin...' link and see that it opens in a new tab and the url is the one that you set in the HELSINKI_PROFIILI_URI above.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR has been visually reviewed by a designer (Heikki)

[LOM-348]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ