### PR TITLE
LOM-356: hardcoding for MVP as this page is never seen again after this.

### DIFF
--- a/public/modules/custom/webform_formtool_handler/templates/submission-print.html.twig
+++ b/public/modules/custom/webform_formtool_handler/templates/submission-print.html.twig
@@ -15,10 +15,12 @@
         <div class="submission-print__header-branding"¨>
           <div class="submission-print__header-branding-block">
             <div class="submission-print__sector-name">
-              {{ sector }}
+              {{ "City of Helsinki, Educatioivision / Archives"|t }}
             </div>
             <div class="submission-print__sector-address">
-              {{ address|replace({"\n":'<br/>', "\r":''})|raw }}
+              {{ "Töysänkatu 2 D"|t }}
+              <br/>
+              {{ "00510 Helsinki"|t }}
             </div>
           </div>
           <div class="submission-print__header-branding-right">

--- a/public/modules/custom/webform_formtool_handler/translations/fi/fi.po
+++ b/public/modules/custom/webform_formtool_handler/translations/fi/fi.po
@@ -21,3 +21,15 @@ msgstr "Lomake lähetetty"
 
 msgid "Print the form"
 msgstr "Tulosta lomake"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "City of Helsinki, Educatioivision / Archives"
+msgstr "Kasvatuksen ja koulutuksen toimiala / Arkisto"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "Töysänkatu 2 D"
+msgstr "Töysänkatu 2 D"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "00510 Helsinki"
+msgstr "00510 Helsinki"

--- a/public/modules/custom/webform_formtool_handler/translations/sv/sv.po
+++ b/public/modules/custom/webform_formtool_handler/translations/sv/sv.po
@@ -21,3 +21,15 @@ msgstr "Blanketten har skickats"
 
 msgid "Print the form"
 msgstr "Skriv ut blanketten"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "City of Helsinki, Educatioivision / Archives"
+msgstr "Fostrans och utbildningssektorn / Arkivet"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "Töysänkatu 2 D"
+msgstr "Töysägatan 2 D"
+
+msgctxt "Submission Print page for the MVP form"
+msgid "00510 Helsinki"
+msgstr "00510 Helsingfors"


### PR DESCRIPTION
# [LOM-356](https://helsinkisolutionoffice.atlassian.net/browse/LOM-356)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Since the Seurantasivu is only for the one MVP form and the stuff in the esitietolomake is not used anywhere else as it stands, the texts on the page can be set by hardcoding. The address and the toimiala are now printed correctly on the seurantasivu.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-356-address-to-seurantasivu`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill out form, go to seurantasivu
* [ ] See that the address and name of the toimiala are correct
* [ ] Make sure that the translations are correct as well.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[LOM-356]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ