### PR TITLE
LOM-333: Add delivery method to text format function

### DIFF
--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/form_tool_contact_info.info.yml
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/form_tool_contact_info.info.yml
@@ -12,4 +12,4 @@ project: 'webform'
 datestamp: 1620250261
 
 'interface translation project': form_tool_contact_info
-'interface translation server pattern': public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/%language/%language.po
+'interface translation server pattern': modules/custom/form_tool_webform_components/form_tool_contact_info/translations/%language/%language.po

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Element/FormToolContactInfo.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Element/FormToolContactInfo.php
@@ -123,7 +123,7 @@ class FormToolContactInfo extends WebformCompositeBase {
     ];
     $elements['cod'] = [
       '#type' => 'item',
-      '#markup' => t('Cash on delviery price is 9,20 €'),
+      '#markup' => t('Cash on delivery price is 9,20 €'),
       '#after_build' => [[get_called_class(), 'codPostalAddress']],
     ];
     $elements['cod_first_name'] = [
@@ -215,7 +215,7 @@ class FormToolContactInfo extends WebformCompositeBase {
     ];
     $elements['Postiennakko -teksti'] = [
       '#type' => 'item',
-      '#title' => t('Cash on delviery price is 9,20 €'),
+      '#title' => t('Cash on delivery price is 9,20 €'),
     ];
     $elements['Nouto -teksti'] = [
       '#type' => 'textfield',

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
@@ -313,19 +313,31 @@ class FormToolContactInfo extends WebformCompositeBase {
 
     switch ($value["delivery_method"]) {
       case 'email':
+        $ttd = $this->t('Delivery');
+        $ttemail = $this->t('Email');
+        $lines[] = $ttd->render() . ': ' . $ttemail->render();
         $lines[] = $value['email'];
         break;
 
       case 'pickup':
-        $tt = $this->t('Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta. Töysänkatu 2 D, 00510 Helsinki.');
+        $ttd = $this->t('Delivery');
+        $ttp = $this->t('Pickup');
+        $tt = $this->t('Pick-up from Töysänkatu 2 D, 00510 Helsinki.');
+        $lines[] = $ttd->render() . ': ' . $ttp->render();
         $lines[] = $tt->render();
         break;
 
       case 'postal':
+        $ttd = $this->t('Delivery');
+        $ttpostal = $this->t('Postal Delivery');
+        $lines[] = $ttd->render() . ': ' . $ttpostal->render();
         $lines[] = $value['first_name'] . ' ' . $value['last_name'];
         break;
 
       case 'cod':
+        $ttd = $this->t('Delivery');
+        $ttcod = $this->t('Cash on Delivery');
+        $lines[] = $ttd->render() . ': ' . $ttcod->render();
         $lines[] = $value['cod_first_name'] . ' ' . $value['cod_last_name'];
         $lines[] = $value['cod_street_address'] . ' ' . $value['cod_zip_code'] . ' ' . $value['cod_city'];
         $lines[] = $value['cod_phone_number'];

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
@@ -313,34 +313,33 @@ class FormToolContactInfo extends WebformCompositeBase {
 
     switch ($value["delivery_method"]) {
       case 'email':
-        $ttd = $this->t('Delivery');
         $ttemail = $this->t('Email');
-        $lines[] = $ttd->render() . ': ' . $ttemail->render();
+        $lines[] = $ttemail->render();
         $lines[] = $value['email'];
         break;
 
       case 'pickup':
-        $ttd = $this->t('Delivery');
         $ttp = $this->t('Pickup');
         $tt = $this->t('Pick-up from Töysänkatu 2 D, 00510 Helsinki.');
-        $lines[] = $ttd->render() . ': ' . $ttp->render();
-        $lines[] = $tt->render();
+        $lines[] = $ttp->render() . '. ' . $tt->render();
         break;
 
       case 'postal':
-        $ttd = $this->t('Delivery');
         $ttpostal = $this->t('Postal Delivery');
         $lines[] = $ttd->render() . ': ' . $ttpostal->render();
         $lines[] = $value['first_name'] . ' ' . $value['last_name'];
         break;
 
       case 'cod':
-        $ttd = $this->t('Delivery');
         $ttcod = $this->t('Cash on Delivery');
-        $lines[] = $ttd->render() . ': ' . $ttcod->render();
-        $lines[] = $value['cod_first_name'] . ' ' . $value['cod_last_name'];
-        $lines[] = $value['cod_street_address'] . ' ' . $value['cod_zip_code'] . ' ' . $value['cod_city'];
-        $lines[] = $value['cod_phone_number'];
+        $codtext = $this->t('Cash on delivery price is 9,20 €');
+        $deliveryaddress = $this->t('Delivery Address');
+        $zip = $this->t('Zip Code');
+        $city = $this->t('City');
+        $lines[] = '<p>' . $ttcod->render() . '. ' . $codtext->render() . '</p>';
+        $lines[] = '<p class="label">' . $deliveryaddress->render() . '</p>';
+        $lines[] = $value['cod_street_address'];
+        $lines[] = $value['cod_zip_code'] . ' ' . $value['cod_city'];
         break;
 
       default:

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Plugin/WebformElement/FormToolContactInfo.php
@@ -326,7 +326,7 @@ class FormToolContactInfo extends WebformCompositeBase {
 
       case 'postal':
         $ttpostal = $this->t('Postal Delivery');
-        $lines[] = $ttd->render() . ': ' . $ttpostal->render();
+        $lines[] = $ttpostal->render();
         $lines[] = $value['first_name'] . ' ' . $value['last_name'];
         break;
 
@@ -334,8 +334,6 @@ class FormToolContactInfo extends WebformCompositeBase {
         $ttcod = $this->t('Cash on Delivery');
         $codtext = $this->t('Cash on delivery price is 9,20 €');
         $deliveryaddress = $this->t('Delivery Address');
-        $zip = $this->t('Zip Code');
-        $city = $this->t('City');
         $lines[] = '<p>' . $ttcod->render() . '. ' . $codtext->render() . '</p>';
         $lines[] = '<p class="label">' . $deliveryaddress->render() . '</p>';
         $lines[] = $value['cod_street_address'];

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
@@ -5,7 +5,7 @@ msgid "Selecting a delivery method may prompt further questions"
 msgstr "Toimitustavan valinta voi vaatia lisäkenttien täyttämistä"
 
 msgid "Email"
-msgstr "Sähköpostiosoite"
+msgstr "Sähköposti"
 
 msgid "Email Address"
 msgstr "Sähköpostiosoite"
@@ -21,6 +21,9 @@ msgstr "Nouto"
 
 msgid "Delivery"
 msgstr "Toimitustapa"
+
+msgid "Delivery Address"
+msgstr "Toimitusosoite"
 
 msgid "First Name"
 msgstr "Etunimi"
@@ -40,7 +43,7 @@ msgstr "Kaupunki"
 msgid "Phone Number"
 msgstr "Puhelinnumero"
 
-msgid "Cash on delviery price is 9,20 €"
+msgid "Cash on delivery price is 9,20 €"
 msgstr "Postiennakon hinta asiakirjan tilaajalle 9,20 €"
 
 msgid "Pick-up from Töysänkatu 2 D, 00510 Helsinki."

--- a/public/themes/custom/hdbt_subtheme/src/scss/06_components/layout/_submission_print.scss
+++ b/public/themes/custom/hdbt_subtheme/src/scss/06_components/layout/_submission_print.scss
@@ -102,11 +102,15 @@
     size: A4;
     margin: 0;
   }
-  label {
+  label,
+  p.label {
     font-size: var(--fontsize-body-m);
     font-weight: bold;
     display: block;
     margin-bottom: var(--spacing-s);
+  }
+  p.label {
+    margin-bottom: 0;
   }
   &__sector-name {
     margin-bottom: var(--spacing-l);


### PR DESCRIPTION
# [LOM-333](https://helsinkisolutionoffice.atlassian.net/browse/LOM-333)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Delivery method was not shown in seurantasivu, it is now.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-333-delivery-method`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login and submit form in https://hel-fi-form-tool.docker.so/fi/lomakkeet/todistusjaljennospyynto-tilaus
* [ ] Click Katso lähettämäsi tiedot
* [ ] Scroll down and make sure you see the delivery method

![image](https://user-images.githubusercontent.com/26737690/217268796-42c526ae-f496-4acc-b42e-48df8d930a54.png)




[LOM-333]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ