### PR TITLE
Feature/lom 374 security testing build

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17afd549b38c849792f9c339a5afbdf8",
+    "content-hash": "179899f6bf364342e367c56ae21e17c7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4959,12 +4959,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili.git",
-                "reference": "d78507750a7d6fa4303990580965755790e8fa85"
+                "reference": "f1b3a720fe992fcd7ef53b74715d1b9b51a1a10a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/zipball/d78507750a7d6fa4303990580965755790e8fa85",
-                "reference": "d78507750a7d6fa4303990580965755790e8fa85",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/zipball/f1b3a720fe992fcd7ef53b74715d1b9b51a1a10a",
+                "reference": "f1b3a720fe992fcd7ef53b74715d1b9b51a1a10a",
                 "shasum": ""
             },
             "require": {
@@ -4992,7 +4992,7 @@
                 "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/tree/develop",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/issues"
             },
-            "time": "2023-02-01T13:58:10+00:00"
+            "time": "2023-02-07T12:25:04+00:00"
         },
         {
             "name": "drupal/helfi_media_formtool",

--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
@@ -282,7 +282,7 @@ class FormToolProfileData extends WebformCompositeBase {
         '#url' => $profileEditUrl,
         '#attributes' => ['target' => '_blank'],
         '#title' => t('Go to Helsinki-profile to edit your information.'),
-        '#suffix' => '('.t('the link opens in a new tab').')',
+        '#suffix' => '(' . t('the link opens in a new tab') . ')',
       ],
       'refreshLink' => [
         '#type' => 'link',

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -149,6 +149,7 @@ class HelfiGdprApiController extends ControllerBase {
       'audience_host' => getenv('GDPR_API_AUD_HOST'),
     ];
 
+
     $this->setDebug(getenv('DEBUG') == 'true' || getenv('DEBUG') == TRUE);
     $this->parseJwt();
 

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -149,7 +149,6 @@ class HelfiGdprApiController extends ControllerBase {
       'audience_host' => getenv('GDPR_API_AUD_HOST'),
     ];
 
-
     $this->setDebug(getenv('DEBUG') == 'true' || getenv('DEBUG') == TRUE);
     $this->parseJwt();
 

--- a/public/modules/custom/webform_formtool_handler/src/FormToolWsAccessHandler.php
+++ b/public/modules/custom/webform_formtool_handler/src/FormToolWsAccessHandler.php
@@ -22,15 +22,17 @@ class FormToolWsAccessHandler extends WebformSubmissionAccessControlHandler {
     $webformOwner = $webform->getOwner();
     $webformOwnerRoles = $webformOwner->getRoles();
     $thirdPartySettings = $webform->getThirdPartySettings('form_tool_webform_parameters');
+    $userRoles = $account->getRoles();
 
     // No access to anonymous to any webform submissions.
     if ($account->isAnonymous()) {
       return WebformAccessResult::forbidden();
     }
 
-    // Admins have access always.
-    if (in_array(['admin', 'verkkolomake_admin'], $webformOwnerRoles)) {
-      return WebformAccessResult::allowed();
+    // Admins DO NOT have access to any submissions.
+    // To allow user access they MUST NOT have these roles.
+    if (in_array(['admin', 'verkkolomake_admin'], $userRoles)) {
+      return WebformAccessResult::forbidden();
     }
 
     // Webform owner has access to submission when in WIP state.
@@ -46,7 +48,7 @@ class FormToolWsAccessHandler extends WebformSubmissionAccessControlHandler {
     $data = $result->fetchObject();
 
     $adminRoles = explode(',', $data->admin_roles);
-    $userRoles = $account->getRoles();
+
     foreach ($adminRoles as $rid) {
       // If user has a role to access this webform submission.
       if (in_array($rid, $userRoles)) {
@@ -57,6 +59,12 @@ class FormToolWsAccessHandler extends WebformSubmissionAccessControlHandler {
     // Admin owner has access if state is WIP.
     if (($thirdPartySettings["status"] == 'wip') && $data->admin_owner == $account->getEmail()) {
       return WebformAccessResult::allowed();
+    }
+
+    // if user does not have either helsinki profile role, they do not have access
+    // and if they do, they must be the submitter below.
+    if (!self::inArrayWildcard($userRoles, 'helsinkiprofiili')) {
+      return WebformAccessResult::forbidden();
     }
 
     /** @var \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $helProfiiliData */
@@ -72,9 +80,27 @@ class FormToolWsAccessHandler extends WebformSubmissionAccessControlHandler {
       return WebformAccessResult::allowed();
     }
 
-    // $access = parent::checkAccess($entity, $operation, $account);
-    // return $access;
     return WebformAccessResult::forbidden();
+  }
+
+  /**
+   * Check if wildcard value is in array.
+   *
+   * @param array $haystack
+   *   Array we're looking for values.
+   * @param string $needle
+   *   Value we want to see if it's in above array.
+   *
+   * @return bool
+   *   True if array is found and false if not.
+   */
+  public static function inArrayWildcard(array $haystack, string $needle): bool {
+    $matches = array_filter($haystack, function ($var) use ($needle) {
+      return (bool) preg_match("/$needle/i", $var);
+    });
+
+    return !empty($matches);
+
   }
 
 }


### PR DESCRIPTION
# [LOM-374](https://helsinkisolutionoffice.atlassian.net/browse/LOM-374)
<!-- What problem does this solve? -->

There was an issue when non-helsinkiprofiili user tried to access form the system threw fatal error due to missing hp tokens.

This makes the access callback to check user roles before hp even becomes an issue, and user should not be able to get that far without helsinkiprofiili_* role.

Also general Hallinnoija role had access to submissions, this is removed. ONLY user with correct handler role is granted.

## What was done
<!-- Describe what was done -->

* Add new role check before checking hp access
* remove access to admin / hallinnoija level users.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-374-security-testing-build`
  * `make fresh`
* Run `make drush-cr`
*

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Login with (all in separate browsers)
  * normal user via Tunnistamo
  * VerkkolomakeAdmin user
  * VerkkolomakeHallllinoija user
  * todistusjäljennöspyyntö hallinnoija role
  * 
* Submit new form with normal user
* Try accessing with both hallinnoija & admin users, form hallinnoija should be granted access while VerkkolomakeHallllinoija & VerkkolomakeAdmin should not
* You should see no errors regarding missing hp tokens.




[LOM-374]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ