### PR TITLE
fix: LOM-397: change location of privacy policy link

### DIFF
--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -95,6 +95,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
         '#required' => TRUE,
       ];
     }
+    
     $temp = $form['elements']['actions'];
     unset($form['elements']['actions']);
     $form['elements']['actions'] = $temp;

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -81,20 +81,23 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
       $privacy_policy_string = t('Read more about <a href="@privacy-policy-link" class="privacy-policy-link" target="_blank">the privacy policy</a> (the link will open in a new tab).', [
         '@privacy-policy-link' => _form_tool_webform_parameters_get_default_privacy_policy_link($formsettings),
       ]);
-      $form['privacy_policy_wrapper'] = [
+      $form['elements']['privacy_policy_wrapper'] = [
         '#type' => 'webform_section',
         '#title' => t('Privacy Policy'),
       ];
-      $form['privacy_policy_wrapper']['privacy_policy_link'] = [
+      $form['elements']['privacy_policy_wrapper']['privacy_policy_link'] = [
         '#type' => 'label',
         '#title' => $privacy_policy_string,
       ];
-      $form['privacy_policy_wrapper']['privacy_policy_acceptance'] = [
+      $form['elements']['privacy_policy_wrapper']['privacy_policy_acceptance'] = [
         '#type' => 'checkbox',
         '#title' => t('I have read the privacy policy'),
         '#required' => TRUE,
       ];
     }
+    $temp = $form['elements']['actions'];
+    unset($form['elements']['actions']);
+    $form['elements']['actions'] = $temp;
   }
   if ($form_id == 'webform_settings_form' || $form_id == 'webform_add_form' || $form_id == 'webform_duplicate_form') {
 

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -95,7 +95,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
         '#required' => TRUE,
       ];
     }
-    
+
     $temp = $form['elements']['actions'];
     unset($form['elements']['actions']);
     $form['elements']['actions'] = $temp;


### PR DESCRIPTION
# [LOM-397](https://helsinkisolutionoffice.atlassian.net/browse/LOM-397)
<!-- What problem does this solve? -->
Privacy policy link is again in the correct location

## What was done
<!-- Describe what was done -->

* Moved the privacy policy link (and wrapper) to the correct place, both in the order of the form (before the submit button) and the code (inside the elements array)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-397-form-submit-button-place`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Navigate to the form, log in if necessary
* [ ] See that the privacy policy link is on the form before the submit button
* [ ] Submit form without accepting the privacy policy, see that you can't as it's a required field
* [ ] Check the checkbox and submit the form, see that the form submits
* [ ] Go to the seurantasivu and see that the value of accepting the privacy policy is not passed on to the seurantasivu.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[LOM-397]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ