### PR TITLE
fix: LOM-398: Support naming convention staging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drupal/helfi_atv": "^0.9.0",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_drupal_tools": "dev-main",
-        "drupal/helfi_helsinki_profiili": "^0.9.0",
+        "drupal/helfi_helsinki_profiili": "^0.9",
         "drupal/helfi_platform_config": "^2.0",
         "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tunnistamo": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72ded347f8aa374599136d2e4bca744a",
+    "content-hash": "9ef84c5e9aafa6007a7246af1fc049c3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4824,16 +4824,16 @@
         },
         {
             "name": "drupal/helfi_api_base",
-            "version": "2.3.10",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base.git",
-                "reference": "8b6c0ad0bce4a9d1c19203ae7e880b26f9845325"
+                "reference": "9fef0cb03d5d0e31dba160331bc5365d0b424be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/8b6c0ad0bce4a9d1c19203ae7e880b26f9845325",
-                "reference": "8b6c0ad0bce4a9d1c19203ae7e880b26f9845325",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/9fef0cb03d5d0e31dba160331bc5365d0b424be4",
+                "reference": "9fef0cb03d5d0e31dba160331bc5365d0b424be4",
                 "shasum": ""
             },
             "require": {
@@ -4857,10 +4857,10 @@
             ],
             "description": "Helfi - API Base",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.3.10",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.4.0",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/issues"
             },
-            "time": "2023-01-18T12:10:48+00:00"
+            "time": "2023-02-15T04:42:26+00:00"
         },
         {
             "name": "drupal/helfi_atv",


### PR DESCRIPTION
# [LOM-398](https://helsinkisolutionoffice.atlassian.net/browse/LOM-398)
<!-- What problem does this solve? -->

Our authentications did not work when our staging environment is named staging, when all others are named stage. This maps those.

## What was done
<!-- Describe what was done -->

* Lari fixed this with api base update.


[LOM-398]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ