### PR TITLE
fix: LOM-376: Fix phone validator to allow non-international format

### DIFF
--- a/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_profile_data/src/Element/FormToolProfileData.php
@@ -347,7 +347,7 @@ class FormToolProfileData extends WebformCompositeBase {
     $value = $element['#value'] ?? NULL;
 
     if (!empty($value)) {
-      $valid = preg_match("/^\+[\d]+\b/", $value);
+      $valid = preg_match("/^\+?[\d]+\b/", $value);
       if (!$valid) {
         $form_state->setError($element, t('%name is not a valid number.', [
           '%name' => t('Primary phone'),


### PR DESCRIPTION
# [LOM-376](https://helsinkisolutionoffice.atlassian.net/browse/LOM-376)
<!-- What problem does this solve? -->

## What was done

* Changed validator to allow non-international number format

## How to install

* Make sure your instance is up and running on correct branch.
  * `feature/LOM-376-phone-validator-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Login to form
* [ ] Try to find Helsinki Profile with a number in non-international format (or hardcode value in `FormToolProfileData:::validatePhoneNumber`)
* [ ] Test that both formats are accepted while submitting the form

## Designer review

* [x] This PR does not need designers review




[LOM-376]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ