### PR TITLE
feat: LOM-352: Installed audit log module. Configuring audit log events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_atv": "^0.9.0",
+        "drupal/helfi_audit_log": "^0.9",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_drupal_tools": "dev-main",
         "drupal/helfi_helsinki_profiili": "^0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ef84c5e9aafa6007a7246af1fc049c3",
+    "content-hash": "e8d67fa1cfeae472d9215d75dd6907a3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4894,6 +4894,35 @@
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/issues"
             },
             "time": "2023-02-07T08:41:36+00:00"
+        },
+        {
+            "name": "drupal/helfi_audit_log",
+            "version": "0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log.git",
+                "reference": "f76d8cad31b59254cbcff890699ba98aca425996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/f76d8cad31b59254cbcff890699ba98aca425996",
+                "reference": "f76d8cad31b59254cbcff890699ba98aca425996",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "drupal/coder": "^8.3"
+            },
+            "type": "drupal-module",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Helfi - Audit log",
+            "support": {
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9",
+                "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/issues"
+            },
+            "time": "2023-02-09T08:48:43+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -37,6 +37,7 @@ module:
   file_mdm: 0
   filter: 0
   focal_point: 0
+  form_tool_auditlog: 0
   form_tool_contact_info: 0
   form_tool_noscript: 0
   form_tool_profile: 0
@@ -54,6 +55,7 @@ module:
   helfi_announcements: 0
   helfi_api_base: 0
   helfi_atv: 0
+  helfi_audit_log: 0
   helfi_base_config: 0
   helfi_charts: 0
   helfi_contact_cards: 0

--- a/public/modules/custom/form_tool_auditlog/form_tool_auditlog.info.yml
+++ b/public/modules/custom/form_tool_auditlog/form_tool_auditlog.info.yml
@@ -1,0 +1,8 @@
+name: 'Form tool audit log'
+type: module
+description: 'Audit log hooks and events.'
+package: 'Helfi'
+version: 0.1
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - helfi_audit_log

--- a/public/modules/custom/form_tool_auditlog/form_tool_auditlog.module
+++ b/public/modules/custom/form_tool_auditlog/form_tool_auditlog.module
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for Form Tool auditlog module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */
+
+use Drupal\Component\Utility\DiffArray;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\form_tool_auditlog\Event\UserPresaveEvent;
+use Drupal\node\Entity\Node;
+use Drupal\user\UserInterface;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Implements hook_webform_delete().
+ */
+function form_tool_auditlog_webform_delete(Webform $entity) {
+  $message = [
+    'operation' => 'DELETE',
+    'status'    => 'SUCCESS',
+    'target'    => [
+      'id' => $entity->id(),
+      'type' => 'WEBFORM',
+    ],
+    'actor' => [
+      'id' => \Drupal::currentUser()->id(),
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+}
+
+/**
+ * Implements hook_webform_delete().
+ */
+function form_tool_auditlog_webform_insert(Webform $entity) {
+  $message = [
+    'operation' => 'CREATE',
+    'status'    => 'SUCCESS',
+    'target'    => [
+      'id' => $entity->id(),
+      'type' => 'WEBFORM',
+    ],
+    'actor' => [
+      'id' => \Drupal::currentUser()->id(),
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+}
+
+/**
+ * Implements hook_webform_delete().
+ */
+function form_tool_auditlog_webform_update(Webform $entity) {
+
+  if ($entity->isNew()) {
+    return;
+  }
+
+  $diff = array_keys(DiffArray::diffAssocRecursive($entity->toArray(), $entity->original->toArray()));
+
+  $message = [
+    'operation' => 'UPDATE',
+    'status'    => 'SUCCESS',
+    'target'    => [
+      'id' => $entity->id(),
+      'type' => 'WEBFORM',
+      'changes' => $diff,
+    ],
+    'actor' => [
+      'id' => \Drupal::currentUser()->id(),
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+}
+
+/**
+ * Implements hook_node_view().
+ */
+function form_tool_auditlog_node_view(array &$build, Node $node, $display, $view_mode) {
+  if ($node->getType() === 'webform') {
+
+    $webform_relation = $node->get('webform')->getValue()[0] ?? NULL;
+
+    if (!$webform_relation) {
+      return;
+    }
+
+    $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_relation['target_id']);
+
+    $thirdPartySettings = $webform->getThirdPartySettings('form_tool_webform_parameters');
+
+    $requestUserData = \Drupal::request()->getSession()->get('userData');
+    $subId = $requestUserData['sub'] ?? NULL;
+
+    $message = [
+      'operation' => 'READ',
+      'target'    => [
+        'id' => $webform_relation['target_id'],
+        'form_code' => $thirdPartySettings['form_code'] ?? NULL,
+        'type' => 'WEBFORM',
+      ],
+      'actor' => [
+        'user_id' => $subId,
+        'id' => Drupal::currentUser()->id(),
+      ],
+    ];
+
+    \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+  }
+}
+
+/**
+ * Implements hook_openid_connect_post_authorize().
+ */
+function form_tool_auditlog_openid_connect_post_authorize(UserInterface $account, array $context) {
+
+  $message = [
+    'operation' => 'OPENID_LOGIN',
+    'status'    => 'SUCCESS',
+    'target' => [
+      'id' => $context['sub'],
+      'type' => 'USER',
+      'name' => 'User Open ID login',
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+}
+
+/**
+ * Implements hook_user_login().
+ */
+function form_tool_auditlog_user_login(AccountInterface $account) {
+  // Regular Drupal login event.
+  $message = [
+    'operation' => 'DRUPAL_LOGIN',
+    'status'    => 'SUCCESS',
+    'target' => [
+      'id' => $account->id(),
+      'type' => 'USER',
+      'name' => 'User Login',
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+}
+
+/**
+ * Implements hook_user_logout().
+ */
+function form_tool_auditlog_user_logout(AccountInterface $account) {
+  $userData = \Drupal::request()->getSession()->get('userData');
+  $has_openid = \Drupal::request()->getSession()->get('openid_connect_access') ?? NULL;
+
+  // Open ID logout event.
+  if ($has_openid) {
+    $message = [
+      'operation' => 'OPENID_LOGOUT',
+      'status'    => 'SUCCESS',
+      'target' => [
+        'id' => $userData['sub'],
+        'type' => 'USER',
+        'name' => 'User Open ID logout',
+      ],
+    ];
+
+    \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+  }
+
+  // Regular Drupal logout event.
+  $message = [
+    'operation' => 'DRUPAL_LOGOUT',
+    'status'    => 'SUCCESS',
+    'target' => [
+      'id' => $account->id(),
+      'type' => 'USER',
+      'name' => 'User logout',
+    ],
+  ];
+
+  \Drupal::service('helfi_audit_log.audit_log')->dispatchEvent($message);
+
+}
+
+/**
+ * Implements hook_user_presave().
+ */
+function form_tool_auditlog_user_presave(EntityInterface $entity) {
+  $event = new UserPresaveEvent($entity);
+  $dispatcher = \Drupal::service('event_dispatcher');
+  $dispatcher->dispatch('form_tool_auditlog.user.presave', $event);
+}

--- a/public/modules/custom/form_tool_auditlog/form_tool_auditlog.services.yml
+++ b/public/modules/custom/form_tool_auditlog/form_tool_auditlog.services.yml
@@ -1,0 +1,20 @@
+services:
+  form_tool_auditlog.user_presave_subscriber:
+    class: 'Drupal\form_tool_auditlog\EventSubscriber\UserPresaveSubscriber'
+    arguments: ['@helfi_audit_log.audit_log']
+    tags:
+      - { name: event_subscriber }
+  form_tool_auditlog.submission_view_subscriber:
+    class: 'Drupal\form_tool_auditlog\EventSubscriber\SubmissionViewSubscriber'
+    arguments: ['@helfi_audit_log.audit_log']
+    tags:
+      - { name: event_subscriber }
+  form_tool_auditlog.webform_submission_subscriber:
+    class: 'Drupal\form_tool_auditlog\EventSubscriber\WebformSubmissionSubscriber'
+    arguments: ['@helfi_audit_log.audit_log']
+    tags:
+      - { name: event_subscriber }
+  form_tool_auditlog.audit_log_event_suscriber:
+    class: 'Drupal\form_tool_auditlog\EventSubscriber\AuditLogEventSubscriber'
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/form_tool_auditlog/src/Event/UserPresaveEvent.php
+++ b/public/modules/custom/form_tool_auditlog/src/Event/UserPresaveEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\form_tool_auditlog\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Event for user presave.
+ */
+class UserPresaveEvent extends Event {
+
+  const USER_PRESAVE = 'form_tool_auditlog.user.presave';
+
+  /**
+   * User entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  private $entity;
+
+  /**
+   * Construct a new event.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   A Drupal entity.
+   */
+  public function __construct(EntityInterface $entity) {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Get the entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   A Drupal entity.
+   */
+  public function getUser() {
+
+    return $this->entity;
+  }
+
+}

--- a/public/modules/custom/form_tool_auditlog/src/EventSubscriber/AuditLogEventSubscriber.php
+++ b/public/modules/custom/form_tool_auditlog/src/EventSubscriber/AuditLogEventSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\form_tool_auditlog\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\helfi_audit_log\Event\AuditLogEvent;
+
+/**
+ * Monitors submission view events and logs them to audit log.
+ */
+class AuditLogEventSubscriber implements EventSubscriberInterface {
+
+  const ORIGIN = 'FORM-TOOL-DRUPAL';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[AuditLogEvent::LOG][] = ['onLog'];
+    return $events;
+  }
+
+  /**
+   * Modify audit log events.
+   *
+   * @param \Drupal\helfi_audit_log\Event\AuditLogEvent $event
+   *   An AuditLogEvent event.
+   */
+  public function onLog(AuditLogEvent $event) {
+    $event->setOrigin(self::ORIGIN);
+  }
+
+}

--- a/public/modules/custom/form_tool_auditlog/src/EventSubscriber/SubmissionViewSubscriber.php
+++ b/public/modules/custom/form_tool_auditlog/src/EventSubscriber/SubmissionViewSubscriber.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\form_tool_auditlog\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\form_tool_share\Event\SubmissionViewEvent;
+use Drupal\helfi_audit_log\AuditLogServiceInterface;
+
+/**
+ * Monitors submission view events and logs them to audit log.
+ */
+class SubmissionViewSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The audit log service.
+   *
+   * @var \Drupal\helfi_audit_log\AuditLogServiceInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a logger object.
+   *
+   * @param \Drupal\helfi_audit_log\AuditLogServiceInterface $logger
+   *   A LoggerInterface object.
+   */
+  public function __construct(AuditLogServiceInterface $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[SubmissionViewEvent::SUBMISSION_VIEW][] = ['onSubmissionView'];
+    return $events;
+  }
+
+  /**
+   * Mark submission view to audit log.
+   *
+   * @param \Drupal\form_tool_share\Event\SubmissionViewEvent $event
+   *   A SubmissionViewEvent event.
+   */
+  public function onSubmissionView(SubmissionViewEvent $event) {
+
+    $request = $event->getRequest();
+    $submissionData = $event->getSubmission();
+    $requestUserData = $request->getSession()->get('userData');
+    $user_uuid = $requestUserData['sub'] ?? NULL;
+
+    $message = [
+      'operation' => 'READ',
+      'status'    => 'SUCCESS',
+      'target' => [
+        'id' => $submissionData->submission_uuid,
+        'type' => 'SUBMISSION',
+      ],
+    ];
+
+    if ($user_uuid === $submissionData->user_uuid) {
+      $message['actor'] = [
+        'submitter' => TRUE,
+        'user_id' => $user_uuid,
+      ];
+    }
+    else {
+      $message['actor'] = [
+        'controller' => TRUE,
+        'id' => \Drupal::currentUser()->id(),
+      ];
+    }
+
+    $this->logger->dispatchEvent($message);
+
+  }
+
+}

--- a/public/modules/custom/form_tool_auditlog/src/EventSubscriber/UserPresaveSubscriber.php
+++ b/public/modules/custom/form_tool_auditlog/src/EventSubscriber/UserPresaveSubscriber.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\form_tool_auditlog\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\form_tool_auditlog\Event\UserPresaveEvent;
+use Drupal\helfi_audit_log\AuditLogServiceInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * Monitors all user save events and logs any role/status changes to watchdog.
+ */
+class UserPresaveSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The audit log service.
+   *
+   * @var \Drupal\helfi_audit_log\AuditLogServiceInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a logger object.
+   *
+   * @param \Drupal\helfi_audit_log\AuditLogServiceInterface $logger
+   *   A LoggerInterface object.
+   */
+  public function __construct(AuditLogServiceInterface $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[UserPresaveEvent::USER_PRESAVE][] = ['onUserPresave'];
+    return $events;
+  }
+
+  /**
+   * Get the user being saved and see if there are role changes to log.
+   *
+   * @param \Drupal\role_log\Event\UserPresaveEvent $event
+   *   A UserPresaveEvent event.
+   */
+  public function onUserPresave(UserPresaveEvent $event) {
+    $user = $event->getUser();
+    $this->logRoleChanges($user);
+  }
+
+  /**
+   * Log role changes.
+   *
+   * @param \Drupal\user\Entity\User $user
+   *   A user entity.
+   */
+  protected function logRoleChanges(User $user) {
+
+    if (!$user->isNew()) {
+      $original = $user->original;
+      $old_roles = $original->getRoles();
+      $new_roles = $user->getRoles();
+
+      // Only log saves of existing users if there are role changes.
+      if ($old_roles != $new_roles) {
+        $message = [
+          'operation' => 'UPDATE',
+          'target' => [
+            'id' => $user->id(),
+            'type' => 'USER',
+            'name' => 'User role update',
+            'old_roles' => $old_roles,
+            'new_roles' => $new_roles,
+            'removed_roles' => array_diff($old_roles, $new_roles),
+            'added_roles' => array_diff($new_roles, $old_roles),
+          ],
+          'actor' => [
+            'id' => \Drupal::currentUser()->id(),
+          ],
+        ];
+
+        $this->logger->dispatchEvent($message);
+      }
+    }
+  }
+
+}

--- a/public/modules/custom/form_tool_auditlog/src/EventSubscriber/WebformSubmissionSubscriber.php
+++ b/public/modules/custom/form_tool_auditlog/src/EventSubscriber/WebformSubmissionSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\form_tool_auditlog\EventSubscriber;
+
+use Drupal\helfi_audit_log\AuditLogServiceInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\webform_formtool_handler\Event\WebformSubmissionEvent;
+
+/**
+ * Monitors submission view events and logs them to audit log.
+ */
+class WebformSubmissionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The audit log service.
+   *
+   * @var \Drupal\helfi_audit_log\AuditLogServiceInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a logger object.
+   *
+   * @param \Drupal\helfi_audit_log\AuditLogServiceInterface $logger
+   *   A LoggerInterface object.
+   */
+  public function __construct(AuditLogServiceInterface $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[WebformSubmissionEvent::SUBMISSION_EVENT][] = ['onSubmissionCreate'];
+    return $events;
+  }
+
+  /**
+   * Mark submission to audit log.
+   *
+   * @param \Drupal\webform_formtool_handler\Event\WebformSubmissionEvent $event
+   *   A WebformSubmissionEvent event.
+   */
+  public function onSubmissionCreate(WebformSubmissionEvent $event) {
+
+    $webform_submission = $event->getSubmission();
+    $atvDocument = $event->getAtvDocument();
+    $formToolSubmissionId = $event->getSubmissionId();
+
+    $message = [
+      'operation' => 'CREATE',
+      'status'    => 'SUCCESS',
+      'target' => [
+        'user_id' => $webform_submission->uuid(),
+        'type' => 'SUBMISSION',
+        'name' => 'Webform submission',
+        'document_uuid' => $atvDocument->getId(),
+        'user_uuid' => $atvDocument->getUserId(),
+        'form_tool_id' => $formToolSubmissionId,
+      ],
+      'actor' => [
+        'user_id' => $atvDocument->getUserId(),
+      ],
+    ];
+
+    $this->logger->dispatchEvent($message);
+  }
+
+}

--- a/public/modules/custom/form_tool_share/src/Event/SubmissionViewEvent.php
+++ b/public/modules/custom/form_tool_share/src/Event/SubmissionViewEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\form_tool_share\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Event submission view.
+ */
+class SubmissionViewEvent extends Event {
+
+  const SUBMISSION_VIEW = 'form_tool_share.submission.view';
+
+  /**
+   * Submission row.
+   *
+   * @var object
+   */
+  private $submission;
+
+  /**
+   * Current request object.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  private $request;
+
+  /**
+   * Construct a new event.
+   *
+   * @param object $submission
+   *   Submission database row.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   Request object.
+   */
+  public function __construct(object $submission, Request $request) {
+    $this->submission = $submission;
+    $this->request = $request;
+  }
+
+  /**
+   * Get the entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   A Drupal entity.
+   */
+  public function getRequest() {
+    return $this->request;
+  }
+
+  /**
+   * Get the submission.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   A Drupal entity.
+   */
+  public function getSubmission() {
+    return $this->submission;
+  }
+
+}

--- a/public/modules/custom/webform_formtool_handler/src/Event/WebformSubmissionEvent.php
+++ b/public/modules/custom/webform_formtool_handler/src/Event/WebformSubmissionEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\webform_formtool_handler\Event;
+
+use Drupal\helfi_atv\AtvDocument;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event submission create.
+ */
+class WebformSubmissionEvent extends Event {
+
+  const SUBMISSION_EVENT = 'webform_formtool_handler.submission.create';
+
+  /**
+   * Webform submission object.
+   *
+   * @var \Drupal\webform\WebformSubmissionInterface
+   */
+  private $submission;
+
+  /**
+   * Atv document object.
+   *
+   * @var \Drupal\helfi_atv\AtvDocument
+   */
+  private $atvDocument;
+
+  /**
+   * Submission id.
+   *
+   * @var string
+   */
+  private $submissionId;
+
+  /**
+   * Construct a new event.
+   *
+   * @param Drupal\webform\WebformSubmissionInterface $webform_submission
+   *   Webform submission.
+   * @param \Drupal\helfi_atv\AtvDocument $atv_document
+   *   Atv document object.
+   * @param string $submission_id
+   *   Calculated submission id.
+   */
+  public function __construct(
+    WebformSubmissionInterface $webform_submission,
+    AtvDocument $atv_document,
+    string $submission_id
+  ) {
+    $this->submission = $webform_submission;
+    $this->atvDocument = $atv_document;
+    $this->submissionId = $submission_id;
+  }
+
+  /**
+   * Get the Atv document.
+   *
+   * @return \Drupal\helfi_atv\AtvDocument
+   *   A Drupal entity.
+   */
+  public function getAtvDocument() {
+    return $this->atvDocument;
+  }
+
+  /**
+   * Get the webform submission.
+   *
+   * @return \Drupal\webform\WebformSubmissionInterface
+   *   A Webform submission.
+   */
+  public function getSubmission() {
+    return $this->submission;
+  }
+
+  /**
+   * Get the calculated submission id.
+   *
+   * @return string
+   *   Submission id.
+   */
+  public function getSubmissionId() {
+    return $this->submissionId;
+  }
+
+}


### PR DESCRIPTION
# [LOM-352](https://helsinkisolutionoffice.atlassian.net/browse/LOM-352)
<!-- What problem does this solve? -->

## What was done

* Installed helfi_audit_log module
* Configured events based documentation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-352-audit-logging`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `make shell `-> `drush sqlc`
* [ ] `select * from helfi_audit_logs;` to check log events from DB
* [ ] Following events should log something to database
  - [ ] Drupal login
  - [ ] Drupal logout
  - [ ] Open ID login
  - [ ] Open ID Logout
  - [ ] Webform Submission
  - [ ] Viewing a form
  - [ ] Submission View
  - [ ] Webform creation
  - [ ] Webform edit (components / settings)
  - [ ] Webform deletion
  - [ ] User role changes

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[LOM-352]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ