### PR TITLE
fix: LOM-404: sanity check for element array item in webform

### DIFF
--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -94,11 +94,13 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
         '#title' => t('I have read the privacy policy'),
         '#required' => TRUE,
       ];
+      if (array_key_exists('elements', $form)) {
+        $temp = $form['elements']['actions'];
+        unset($form['elements']['actions']);
+        $form['elements']['actions'] = $temp;
+      }
     }
 
-    $temp = $form['elements']['actions'];
-    unset($form['elements']['actions']);
-    $form['elements']['actions'] = $temp;
   }
   if ($form_id == 'webform_settings_form' || $form_id == 'webform_add_form' || $form_id == 'webform_duplicate_form') {
 


### PR DESCRIPTION
# [LOM-404 ('if' not found)](https://helsinkisolutionoffice.atlassian.net/browse/LOM-404)
<!-- What problem does this solve? -->
AC:
* Sanity checkattu elementin olemassa olo
* Virheviestit poistuneet

## What was done
<!-- Describe what was done -->

* Moved the three lines of code (that move the submit button to the bottom of the webforem) to be:
  * Inside the 'if' that checks that it only happens in webform forms
  * Inside a new if that checks there is an 'elements' array key in form array (even if this should always be true with webform forms) 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-404-warnings-on-forms`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Navigate to the webform without being logged in.
* [ ] Check that there are no errors about 'elements' array key on user login page. (or anywhere else you navigate to)
* [ ] Check that the form actual shows the 'accept privacy policy' checkbox correctly
* [ ] Check that on the submission page the accept privacy policy data isn't printed.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
