### PR TITLE
fix: LOM-359: Add auth support for gdpr token.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/error_page": "^2.0",
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
-        "drupal/helfi_atv": "^0.9.0",
+        "drupal/helfi_atv": "dev-feature/LOM-359-gdpr-atv-auth",
         "drupal/helfi_audit_log": "^0.9",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_drupal_tools": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/error_page": "^2.0",
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
-        "drupal/helfi_atv": "dev-feature/LOM-359-gdpr-atv-auth",
+        "drupal/helfi_atv": "0.9.2",
         "drupal/helfi_audit_log": "^0.9",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_drupal_tools": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c94017e67b4b50a8a550bdfede251a1",
+    "content-hash": "f0b04fa349d103050aacdd7a77697002",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4864,16 +4864,16 @@
         },
         {
             "name": "drupal/helfi_atv",
-            "version": "dev-feature/LOM-359-gdpr-atv-auth",
+            "version": "0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv.git",
-                "reference": "4a90b1e80871edaa304f0042aa1bd877de18509a"
+                "reference": "aa3411d47254f952b32c8a11eb840dc2a1048672"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/4a90b1e80871edaa304f0042aa1bd877de18509a",
-                "reference": "4a90b1e80871edaa304f0042aa1bd877de18509a",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/aa3411d47254f952b32c8a11eb840dc2a1048672",
+                "reference": "aa3411d47254f952b32c8a11eb840dc2a1048672",
                 "shasum": ""
             },
             "require": {
@@ -4890,10 +4890,10 @@
             ],
             "description": "ATV integration module",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/feature/LOM-359-gdpr-atv-auth",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.2",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/issues"
             },
-            "time": "2023-02-17T06:44:10+00:00"
+            "time": "2023-02-17T08:47:39+00:00"
         },
         {
             "name": "drupal/helfi_audit_log",
@@ -18336,7 +18336,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/cache_control_override": 15,
-        "drupal/helfi_atv": 20,
         "drupal/helfi_drupal_tools": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8d67fa1cfeae472d9215d75dd6907a3",
+    "content-hash": "9c94017e67b4b50a8a550bdfede251a1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4864,16 +4864,16 @@
         },
         {
             "name": "drupal/helfi_atv",
-            "version": "0.9.0",
+            "version": "dev-feature/LOM-359-gdpr-atv-auth",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv.git",
-                "reference": "e27719098b42975b9de135ee855bc5b1033186f2"
+                "reference": "4a90b1e80871edaa304f0042aa1bd877de18509a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/e27719098b42975b9de135ee855bc5b1033186f2",
-                "reference": "e27719098b42975b9de135ee855bc5b1033186f2",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/4a90b1e80871edaa304f0042aa1bd877de18509a",
+                "reference": "4a90b1e80871edaa304f0042aa1bd877de18509a",
                 "shasum": ""
             },
             "require": {
@@ -4890,10 +4890,10 @@
             ],
             "description": "ATV integration module",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.0",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/feature/LOM-359-gdpr-atv-auth",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/issues"
             },
-            "time": "2023-02-07T08:41:36+00:00"
+            "time": "2023-02-17T06:44:10+00:00"
         },
         {
             "name": "drupal/helfi_audit_log",
@@ -18336,6 +18336,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/cache_control_override": 15,
+        "drupal/helfi_atv": 20,
         "drupal/helfi_drupal_tools": 20
     },
     "prefer-stable": true,

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -309,8 +309,16 @@ class HelfiGdprApiController extends ControllerBase {
 
   /**
    * Builds the response.
+   *
+   * @param string $userId
+   *   User id.
+   *
+   * @return \Drupal\Component\Serialization\JsonResponse
+   *   JSONresponse.
+   *
+   * @throws \Drupal\helfi_atv\AtvAuthFailedException
    */
-  public function get($userId) {
+  public function get(string $userId) {
 
     // Decode the json data.
     try {
@@ -349,7 +357,7 @@ class HelfiGdprApiController extends ControllerBase {
       $user = $this->getUser();
       $user->delete();
 
-      $this->atvService->deleteGdprData($this->jwtData['sub']);
+      $this->atvService->deleteGdprData($this->jwtData['sub'], $this->jwtToken);
 
     }
     catch (AtvDocumentNotFoundException $e) {

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -250,7 +250,7 @@ class HelfiGdprApiController extends ControllerBase {
       return AccessResult::forbidden('Audience mismatch');
     }
 
-    $hostkey = 'asdf';
+    $hostkey = '';
     if ($this->request->getCurrentRequest()->getMethod() == 'GET') {
 
       // Set hostname for get requests.
@@ -323,25 +323,30 @@ class HelfiGdprApiController extends ControllerBase {
     // Decode the json data.
     try {
       $data = $this->getData();
+      $statusCode = 200;
+      if (empty($data)) {
+        $data = NULL;
+        $statusCode = 204;
+      }
     }
     catch (AtvDocumentNotFoundException $e) {
-      return new JsonResponse(NULL, 404);
+      $data = NULL;
+      $statusCode = 204;
     }
     catch (AtvFailedToConnectException $e) {
-      return new JsonResponse(NULL, 500);
+      $data = NULL;
+      $statusCode = 500;
     }
     catch (TokenExpiredException $e) {
-      return new JsonResponse(NULL, 401);
+      $data = NULL;
+      $statusCode = 401;
     }
     catch (GuzzleException $e) {
-      return new JsonResponse(NULL, 500);
+      $data = NULL;
+      $statusCode = 500;
     }
 
-    if (empty($data)) {
-      return new JsonResponse(NULL, 404);
-    }
-
-    return new JsonResponse($data);
+    return new JsonResponse($data, $statusCode);
 
   }
 
@@ -358,28 +363,29 @@ class HelfiGdprApiController extends ControllerBase {
       $user->delete();
 
       $this->atvService->deleteGdprData($this->jwtData['sub'], $this->jwtToken);
+      $statusCode = 204;
 
     }
     catch (AtvDocumentNotFoundException $e) {
-      return new JsonResponse(NULL, 404);
+      $statusCode = 404;
     }
     catch (AtvFailedToConnectException $e) {
-      return new JsonResponse(NULL, 500);
+      $statusCode = 500;
     }
     catch (TokenExpiredException $e) {
-      return new JsonResponse(NULL, 401);
+      $statusCode = 401;
     }
     catch (GuzzleException $e) {
-      return new JsonResponse(NULL, 500);
+      $statusCode = 500;
     }
     catch (EntityStorageException $e) {
-      return new JsonResponse(NULL, 404);
+      $statusCode = 204;
     }
     catch (AtvAuthFailedException $e) {
-      return new JsonResponse(NULL, 403);
+      $statusCode = 403;
     }
 
-    return new JsonResponse(NULL, 204);
+    return new JsonResponse(NULL, $statusCode);
 
   }
 

--- a/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_gdpr_api/src/Controller/HelfiGdprApiController.php
@@ -34,7 +34,8 @@ use Firebase\JWT\ExpiredException;
 /**
  * Returns responses for helfi_gdpr_api routes.
  */
-class HelfiGdprApiController extends ControllerBase {
+class HelfiGdprApiController extends ControllerBase
+{
 
   /**
    * Profiili data access.
@@ -112,7 +113,8 @@ class HelfiGdprApiController extends ControllerBase {
    * @return bool
    *   Debug on / off?
    */
-  public function isDebug(): bool {
+  public function isDebug(): bool
+  {
     return $this->debug;
   }
 
@@ -122,21 +124,29 @@ class HelfiGdprApiController extends ControllerBase {
    * @param bool $debug
    *   True / False?
    */
-  public function setDebug(bool $debug): void {
+  public function setDebug(bool $debug): void
+  {
     $this->debug = $debug;
   }
 
   /**
    * CompanyController constructor.
+   * @param RequestStack $request
+   * @param HelsinkiProfiiliUserData $helsinkiProfiiliUserData
+   * @param AtvService $atvService
+   * @param ClientInterface $http_client
+   * @param CurrentLanguageContext $currentLanguageContext
+   * @param Connection $connection
    */
   public function __construct(
-    RequestStack $request,
+    RequestStack             $request,
     HelsinkiProfiiliUserData $helsinkiProfiiliUserData,
-    AtvService $atvService,
-    ClientInterface $http_client,
-    CurrentLanguageContext $currentLanguageContext,
-    Connection $connection
-  ) {
+    AtvService               $atvService,
+    ClientInterface          $http_client,
+    CurrentLanguageContext   $currentLanguageContext,
+    Connection               $connection
+  )
+  {
     $this->request = $request;
     $this->helsinkiProfiiliUserData = $helsinkiProfiiliUserData;
     $this->atvService = $atvService;
@@ -158,7 +168,8 @@ class HelfiGdprApiController extends ControllerBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container)
+  {
     return new static(
       $container->get('request_stack'),
       $container->get('helfi_helsinki_profiili.userdata'),
@@ -172,7 +183,8 @@ class HelfiGdprApiController extends ControllerBase {
   /**
    * Checks access for this controller.
    */
-  public function access($userId): AccessResultForbidden|AccessResultAllowed {
+  public function access($userId): AccessResultForbidden|AccessResultAllowed
+  {
 
     $deniedReason = NULL;
     $decoded = NULL;
@@ -181,38 +193,31 @@ class HelfiGdprApiController extends ControllerBase {
       $this->debug('GDPR Api access called. JWT token: @token', ['@token' => $this->jwtToken]);
       $decoded = $this->helsinkiProfiiliUserData->verifyJwtToken($this->jwtToken);
       $this->debug('GDPR Api access called. JWT token contents: @token', ['@token' => Json::encode($decoded)]);
-    }
-    catch (\InvalidArgumentException $e) {
+    } catch (\InvalidArgumentException $e) {
       $deniedReason = $e->getMessage();
-    }
-    catch (\DomainException $e) {
+    } catch (\DomainException $e) {
       // Provided algorithm is unsupported OR
       // provided key is invalid OR
       // unknown error thrown in openSSL or libsodium OR
       // libsodium is required but not available.
       $deniedReason = $e->getMessage();
-    }
-    catch (SignatureInvalidException $e) {
+    } catch (SignatureInvalidException $e) {
       // Provided JWT signature verification failed.
       $deniedReason = $e->getMessage();
-    }
-    catch (BeforeValidException $e) {
+    } catch (BeforeValidException $e) {
       // Provided JWT is trying to be used before "nbf" claim OR
       // provided JWT is trying to be used before "iat" claim.
       $deniedReason = $e->getMessage();
-    }
-    catch (ExpiredException $e) {
+    } catch (ExpiredException $e) {
       // Provided JWT is trying to be used after "exp" claim.
       $deniedReason = $e->getMessage();
-    }
-    catch (\UnexpectedValueException $e) {
+    } catch (\UnexpectedValueException $e) {
       // Provided JWT is malformed OR
       // provided JWT is missing an algorithm / using an unsupported algorithm
       // provided JWT algorithm does not match provided key OR
       // provided key ID in key/key-array is empty or invalid.
       $deniedReason = $e->getMessage();
-    }
-    catch (GuzzleException $e) {
+    } catch (GuzzleException $e) {
       // Generic guzzle exception.
       $deniedReason = $e->getMessage();
     }
@@ -220,8 +225,7 @@ class HelfiGdprApiController extends ControllerBase {
     if ($decoded == NULL) {
       if ($deniedReason == NULL) {
         return AccessResult::forbidden('JWT verification failed.');
-      }
-      else {
+      } else {
         return AccessResult::forbidden($deniedReason);
       }
     }
@@ -243,8 +247,7 @@ class HelfiGdprApiController extends ControllerBase {
       // Set hostname for get requests.
       if (isset($decoded[$this->audienceConfig["audience_host"]])) {
         $hostkey = $this->audienceConfig["service_name"] . '.gdprquery';
-      }
-      else {
+      } else {
         $this->debug(
           'Local access DENIED. Reason: @reason. JWT token: @token',
           [
@@ -260,8 +263,7 @@ class HelfiGdprApiController extends ControllerBase {
       // Same with delete requests, but key used is different.
       if (isset($decoded[$this->audienceConfig["audience_host"]])) {
         $hostkey = $this->audienceConfig["service_name"] . '.gdprdelete';
-      }
-      else {
+      } else {
         $this->debug(
           'Local access DENIED. Reason: @reason. JWT token: @token',
           [
@@ -280,16 +282,14 @@ class HelfiGdprApiController extends ControllerBase {
           '@reason' => 'All match..',
         ]);
       return AccessResult::allowed();
-    }
-    else {
+    } else {
       $deniedReason = 'Scope mismatch';
     }
 
     // We should never reach here, but just return forbidden access.
     if ($deniedReason != NULL) {
       return AccessResult::forbidden($deniedReason);
-    }
-    else {
+    } else {
       return AccessResult::forbidden('Generic token parse error');
     }
   }
@@ -297,22 +297,19 @@ class HelfiGdprApiController extends ControllerBase {
   /**
    * Builds the response.
    */
-  public function get($userId) {
+  public function get($userId)
+  {
 
     // Decode the json data.
     try {
       $data = $this->getData();
-    }
-    catch (AtvDocumentNotFoundException $e) {
+    } catch (AtvDocumentNotFoundException $e) {
       return new JsonResponse(NULL, 404);
-    }
-    catch (AtvFailedToConnectException $e) {
+    } catch (AtvFailedToConnectException $e) {
       return new JsonResponse(NULL, 500);
-    }
-    catch (TokenExpiredException $e) {
+    } catch (TokenExpiredException $e) {
       return new JsonResponse(NULL, 401);
-    }
-    catch (GuzzleException $e) {
+    } catch (GuzzleException $e) {
       return new JsonResponse(NULL, 500);
     }
 
@@ -330,7 +327,8 @@ class HelfiGdprApiController extends ControllerBase {
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   JsonResponse.
    */
-  public function delete($userId): JsonResponse {
+  public function delete($userId): JsonResponse
+  {
 
     try {
       $user = $this->getUser();
@@ -338,23 +336,17 @@ class HelfiGdprApiController extends ControllerBase {
 
       $this->atvService->deleteGdprData($this->jwtData['sub']);
 
-    }
-    catch (AtvDocumentNotFoundException $e) {
+    } catch (AtvDocumentNotFoundException $e) {
       return new JsonResponse(NULL, 404);
-    }
-    catch (AtvFailedToConnectException $e) {
+    } catch (AtvFailedToConnectException $e) {
       return new JsonResponse(NULL, 500);
-    }
-    catch (TokenExpiredException $e) {
+    } catch (TokenExpiredException $e) {
       return new JsonResponse(NULL, 401);
-    }
-    catch (GuzzleException $e) {
+    } catch (GuzzleException $e) {
       return new JsonResponse(NULL, 500);
-    }
-    catch (EntityStorageException $e) {
+    } catch (EntityStorageException $e) {
       return new JsonResponse(NULL, 404);
-    }
-    catch (AtvAuthFailedException $e) {
+    } catch (AtvAuthFailedException $e) {
       return new JsonResponse(NULL, 403);
     }
 
@@ -365,7 +357,8 @@ class HelfiGdprApiController extends ControllerBase {
   /**
    * Parse jwt token data from token in request.
    */
-  public function parseJwt(): void {
+  public function parseJwt(): void
+  {
 
     $currentRequest = $this->request->getCurrentRequest();
 
@@ -392,7 +385,8 @@ class HelfiGdprApiController extends ControllerBase {
    * @throws \Drupal\helfi_helsinki_profiili\TokenExpiredException
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function getData(): array {
+  public function getData(): array
+  {
 
     $data = [];
 
@@ -466,7 +460,7 @@ class HelfiGdprApiController extends ControllerBase {
     }
 
     // Get data.
-    $gdprData = $this->atvService->getGdprData($this->jwtData['sub']);
+    $gdprData = $this->atvService->getGdprData($this->jwtData['sub'], $this->jwtToken);
     if ($gdprData["total_deletable"] == 0 && $gdprData["total_undeletable"] == 0) {
       return [];
     }
@@ -584,7 +578,8 @@ class HelfiGdprApiController extends ControllerBase {
    * @return \Drupal\Core\Entity\EntityBase|\Drupal\Core\Entity\EntityInterface|\Drupal\user\Entity\User|null
    *   User or some other types.
    */
-  public function getUser(): User|EntityBase|EntityInterface|null {
+  public function getUser(): User|EntityBase|EntityInterface|null
+  {
     $query = $this->connection->select('users', 'u',);
     $query->join('authmap', 'am', 'am.uid = u.uid');
     $query
@@ -604,7 +599,8 @@ class HelfiGdprApiController extends ControllerBase {
    * @param array $options
    *   Options.
    */
-  private function debug(string $msg, array $options = []) {
+  private function debug(string $msg, array $options = [])
+  {
     if ($this->isDebug()) {
       $this->getLogger('helf_gdpr_api')->debug($msg, $options);
     }


### PR DESCRIPTION
# [LOM-359](https://helsinkisolutionoffice.atlassian.net/browse/LOM-359)
<!-- What problem does this solve? -->

ATV used to support apikey for accessing gdpr data, this was removed. This authenticates with given token.

## What was done
<!-- Describe what was done -->

* Use gdpr token.



[LOM-359]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ