### PR TITLE
LOM-402: move announcements and status messages

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_announcements.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_announcements.yml
@@ -8,8 +8,8 @@ dependencies:
     - hdbt_subtheme
 id: hdbt_subtheme_announcements
 theme: hdbt_subtheme
-region: before_content
-weight: -11
+region: breadcrumb
+weight: -10
 provider: null
 plugin: announcements
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_breadcrumbs.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_breadcrumbs.yml
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_breadcrumbs
 theme: hdbt_subtheme
 region: breadcrumb
-weight: 0
+weight: -11
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
@@ -12,7 +12,7 @@ _core:
 id: hdbt_subtheme_heroblock
 theme: hdbt_subtheme
 region: before_content
-weight: -10
+weight: -12
 provider: null
 plugin: hero_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_messages.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_messages.yml
@@ -10,8 +10,8 @@ _core:
   default_config_hash: cIXgZqCUh5llJLOsOxqd5Tfm0ExTbsfImZVx3yS_jsA
 id: hdbt_subtheme_messages
 theme: hdbt_subtheme
-region: messages
-weight: -3
+region: before_content
+weight: -11
 provider: null
 plugin: system_messages_block
 settings:


### PR DESCRIPTION
# [LOM-402](https://helsinkisolutionoffice.atlassian.net/browse/LOM-402)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved around announcements and status messages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-402-lohkojen-sijoittelu`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that elements are in this order: Announcements, status message, page title
![image](https://user-images.githubusercontent.com/26737690/219607887-26a2239b-7e6b-4f02-8bfc-2796c4751cde.png)


[LOM-402]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ