### PR TITLE
LOM-401: Fix new form default state to WIP

### DIFF
--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -181,7 +181,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
         'closed' => t('Closed'),
       ],
       '#required' => TRUE,
-      '#default_value' => $formStatus ?? 'closed',
+      '#default_value' => $formStatus ?? 'wip',
       '#description' => t('If form is published, then no editing is allowed and form results are submitted to ATV. Work in progress form opens up for testing & developing but not for general public.'),
       '#disabled' => ($currentId == '1' || in_array('admin', $currentRoles)) ? FALSE : $disabled,
     ];


### PR DESCRIPTION
# [LOM-401](https://helsinkisolutionoffice.atlassian.net/browse/LOM-401)
<!-- What problem does this solve? -->

## What was done

New webform default state to WIP

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-401-form-default-state`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Login with user that has permissions to create webforms
* [ ] Check that default state is WIP / Kesken

![image](https://user-images.githubusercontent.com/43133397/219627049-5c87c133-a509-43ee-b2ed-290e93dab418.png)

## Designers review

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)



[LOM-401]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ