### PR TITLE
LOM-386: Add and configure purge users module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tunnistamo": "^2.0",
         "drupal/permissions_filter": "^1.3",
+        "drupal/purge_users": "^3.1",
         "drupal/seckit": "^2.0",
         "drupal/smtp": "^1.0",
         "drupal/twig_debugger": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0b04fa349d103050aacdd7a77697002",
+    "content-hash": "0c8551b6d183ec139f179fc3271b5797",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6471,6 +6471,54 @@
             "homepage": "https://www.drupal.org/project/purge",
             "support": {
                 "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_users",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/purge_users.git",
+                "reference": "8.x-3.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/purge_users-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "afde7eab938770336375f29c3f0615e587829c9d"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.1",
+                    "datestamp": "1655735072",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Andras_Szilagyi",
+                    "homepage": "https://www.drupal.org/user/1217938"
+                },
+                {
+                    "name": "jim.applebee",
+                    "homepage": "https://www.drupal.org/user/2498674"
+                }
+            ],
+            "description": "Purge inactive users after a set interval.",
+            "homepage": "https://www.drupal.org/project/purge_users",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge_users"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -102,6 +102,7 @@ module:
   path: 0
   path_alias: 0
   permissions_filter: 0
+  purge_users: 0
   redirect: 0
   responsive_image: 0
   rest: 0

--- a/conf/cmi/purge_users.settings.yml
+++ b/conf/cmi/purge_users.settings.yml
@@ -1,0 +1,50 @@
+user_never_lastlogin_value: ''
+user_never_lastlogin_period: days
+user_lastlogin_value: '5'
+user_lastlogin_period: hours
+user_inactive_value: ''
+user_inactive_period: days
+user_blocked_value: ''
+user_blocked_period: days
+enabled_never_loggedin_users: false
+enabled_loggedin_users: true
+enabled_inactive_users: false
+enabled_blocked_users: false
+purge_included_users_roles:
+  helsinkiprofiili_heikko: helsinkiprofiili_heikko
+  helsinkiprofiili_vahva: helsinkiprofiili_vahva
+  authenticated: '0'
+  read_only: '0'
+  content_producer: '0'
+  editor: '0'
+  admin: '0'
+  verkkolomake_kasittelija: '0'
+  verkkolomake_hallinnoija: '0'
+  verkkolomake_admin: '0'
+  verkkolomake_kasittelija_todistus: '0'
+  verkkolomake_kasittelija_testi123: '0'
+  verkkolomake_kasittelija_sectest: '0'
+purge_on_cron: true
+inactive_user_notify_subject: 'Your account is deleted'
+inactive_user_notify_text: "Dear User, \r\n\r\nYour account has been deleted due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website. \r\n\r\nThank you"
+send_email_notification: false
+purge_user_cancel_method: user_cancel_delete
+disregard_blocked_users: false
+purge_excluded_users_roles:
+  admin: admin
+  read_only: '0'
+  content_producer: '0'
+  editor: '0'
+  helsinkiprofiili_heikko: '0'
+  helsinkiprofiili_vahva: '0'
+  verkkolomake_kasittelija: '0'
+  verkkolomake_hallinnoija: '0'
+  verkkolomake_admin: '0'
+  verkkolomake_kasittelija_todistus: '0'
+  verkkolomake_kasittelija_testi123: '0'
+  verkkolomake_kasittelija_sectest: '0'
+user_before_deletion_subject: 'Your account will be deleted'
+user_before_deletion_text: "Dear User, \r\n\r\nYour account will be deleted soon due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website.  \r\n\r\nThank you"
+send_email_user_before_notification: false
+user_before_notification_value: ''
+user_before_notification_period: days

--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_menu_local_tasks_alter().
@@ -143,4 +144,21 @@ function form_tool_profile_preprocess_page(&$vars) {
     ];
   }
 
+}
+
+/**
+ * Implements hook_user_predelete().
+ */
+function form_tool_profile_user_predelete(UserInterface $account) {
+  try {
+    $authdata = \Drupal::service('externalauth.authmap')->getAuthData($account->id(), 'openid_connect.tunnistamo');
+    if (isset($authdata['authname'])) {
+      $account->setUsername($authdata['authname']);
+      $account->setEmail(NULL);
+      $account->save();
+    }
+  }
+  catch (\Exception $e) {
+
+  }
 }


### PR DESCRIPTION
# [LOM-386](https://helsinkisolutionoffice.atlassian.net/browse/LOM-386)

## What was done
Installed and configured purge module to purge endusers after 5 hours.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `make shell`
* [ ] `drush cron`
* [ ] Check that users are being removed (tunnistamo-vahva / heikko)


[LOM-386]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ