### PR TITLE
LOM-395: Installed and configured disable_messages module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "drupal/core-recommended": "^9.0",
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",
+        "drupal/disable_messages": "^2.1",
         "drupal/error_page": "^2.0",
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c8551b6d183ec139f179fc3271b5797",
+    "content-hash": "a16a028c7b8db69b400cda6e0e8521a0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3396,6 +3396,77 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/diff",
                 "issues": "https://www.drupal.org/project/issues/diff"
+            }
+        },
+        {
+            "name": "drupal/disable_messages",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/disable_messages.git",
+                "reference": "2.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/disable_messages-2.1.1.zip",
+                "reference": "2.1.1",
+                "shasum": "7fb6a915eefe7c834c713e8e1dcd8f4a6bd279eb"
+            },
+            "require": {
+                "drupal/core": ">=8"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.1.1",
+                    "datestamp": "1651204825",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Zyxware Technologies (zyxware)",
+                    "homepage": "https://www.drupal.org/u/zyxware",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "binnythomas",
+                    "homepage": "https://www.drupal.org/user/3123091"
+                },
+                {
+                    "name": "jijojoseph_zyxware",
+                    "homepage": "https://www.drupal.org/user/3561263"
+                },
+                {
+                    "name": "varunity",
+                    "homepage": "https://www.drupal.org/user/273530"
+                },
+                {
+                    "name": "vimaljoseph",
+                    "homepage": "https://www.drupal.org/user/817380"
+                },
+                {
+                    "name": "zyxware",
+                    "homepage": "https://www.drupal.org/user/222163"
+                }
+            ],
+            "description": "Allows filtering messages shown to the end user using regular expression patterns.",
+            "homepage": "https://drupal.org/project/disable_messages",
+            "keywords": [
+                "content",
+                "display",
+                "messages"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/disable_messages",
+                "issues": "https://drupal.org/project/issues/disable_messages"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -24,6 +24,7 @@ module:
   default_content: 0
   devel: 0
   diff: 0
+  disable_messages: 0
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   editor: 0

--- a/conf/cmi/disable_messages.settings.yml
+++ b/conf/cmi/disable_messages.settings.yml
@@ -1,0 +1,24 @@
+_core:
+  default_config_hash: Ra1wCOv-XTOsjio08D1i49hzjcUlin66zuciiPtpV44
+disable_messages_enable: '1'
+disable_messages_exclude_users: ''
+disable_messages_filter_by_page: 0
+disable_messages_page_filter_paths: ''
+disable_messages_enable_debug: '0'
+disable_messages_debug_visible_div: '0'
+disable_messages_ignore_patterns: "User logged in and data fetched\r\nTo log in to this site, your browser must accept cookies from the domain\r\nYou have already submitted this webform.+\r\nYour message has been sent.\r\nViestisi on lähetetty.\r\nDitt meddelande har skickats.\r\nUnable to send email. Contact the site administrator if the problem persists.\r\nThere was a problem sending.+\r\nKunde inte skicka e-post. Kontakta webbplatsens administratör om problemet kvarstår. \r\nSähköpostin lähettäminen epäonnistui. Ota yhteyttä sivuston ylläpitäjään, jos ongelma toistuu."
+disable_messages_enable_permissions: '0'
+disable_messages_ignore_exclude: '0'
+disable_messages_ignore_case: '1'
+disable_messages_strip_html_tags: '1'
+disable_messages_ignore_regex:
+  - '/^User logged in and data fetched$/i'
+  - '/^To log in to this site, your browser must accept cookies from the domain$/i'
+  - '/^You have already submitted this webform.+$/i'
+  - '/^Your message has been sent.$/i'
+  - '/^Viestisi on lähetetty.$/i'
+  - '/^Ditt meddelande har skickats.$/i'
+  - '/^Unable to send email. Contact the site administrator if the problem persists.$/i'
+  - '/^There was a problem sending.+$/i'
+  - '/^Kunde inte skicka e-post. Kontakta webbplatsens administratör om problemet kvarstår.$/i'
+  - '/^Sähköpostin lähettäminen epäonnistui. Ota yhteyttä sivuston ylläpitäjään, jos ongelma toistuu.$/i'


### PR DESCRIPTION
# [LOM-395](https://helsinkisolutionoffice.atlassian.net/browse/LOM-395)
<!-- What problem does this solve? -->

## What was done

Installed and configured disable_messages module.
Decided to use this module, instead of overwriting messaging service - as we would have anyone had to somehow filter out specific messages. and MessengerInterface doesn't allow some much configuration how to pass metadata.

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-395-filter-system-messages`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Login as normal user.
* [ ] There should not be a message about previous submissions
* [ ] After submission, there should not be any "failed to email etc.." messages
* [ ] There should not be any weird messages all together



[LOM-395]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ