### PR TITLE
feat: LOM-392: Confirmation email templates for submitter and controller.

### DIFF
--- a/public/modules/custom/webform_formtool_handler/src/Service/SubmissionEmailService.php
+++ b/public/modules/custom/webform_formtool_handler/src/Service/SubmissionEmailService.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\webform_formtool_handler\Service;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Url;
+
+/**
+ * EmailService to handle submission confirmation mails.
+ */
+class SubmissionEmailService {
+
+  const MODULE_NAME = 'webform_formtool_handler';
+
+  /**
+   * RedirectService constructor.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   Language manager.
+   * @param \Drupal\Core\Mail\MailManagerInterface $mailManager
+   *   Mail manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   Renderer instance.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger instance.
+   */
+  public function __construct(
+    protected LanguageManagerInterface $languageManager,
+    protected MailManagerInterface $mailManager,
+    protected RendererInterface $renderer,
+    protected MessengerInterface $messenger,
+  ) {
+  }
+
+  /**
+   * Sends a confirmation to the form submitter.
+   *
+   * @param string $to
+   *   Email address to send the email.
+   * @param string $submission_id
+   *   Submission id.
+   */
+  public function sendSubmitterEmail(string $to, string $submission_id) {
+    $key = 'submission_email_notify_submitter';
+    $langCode = $this->languageManager->getCurrentLanguage()->getId();
+    $url = $this->generateSubmissionLink($submission_id);
+
+    $params['message'] = $this->renderEmailBody('submission_email_notify_submitter', $url->toString(), $langCode);
+
+    $send = TRUE;
+
+    $result = $this->mailManager->mail(self::MODULE_NAME, $key, $to, $langCode, $params,
+      NULL, $send);
+
+    $success = $result['result'] === TRUE;
+    if (!$success) {
+      $this->messenger->addError(t('There was a problem sending
+      confirmation message and it was not sent.'), 'error');
+    }
+    else {
+      $this->messenger->addStatus(t('Your message has been sent.'));
+    }
+
+    return $success;
+  }
+
+  /**
+   * Sends a confirmation to a controller person.
+   *
+   * @param string $to
+   *   Email address to send the email.
+   * @param string $submission_id
+   *   Submission id.
+   * @param string $title
+   *   Title of the form.
+   */
+  public function sendControllerEmail(string $to, string $submission_id, string $title) {
+    $key = 'submission_email_notify';
+    // For now all controller mails are in finnish.
+    $langCode = 'fi';
+    $url = $this->generateSubmissionLink($submission_id);
+
+    $params['message'] = $this->renderEmailBody('submission_email_notify', $url->toString(), $langCode, $title);
+    $params['form_title'] = $title;
+
+    $send = TRUE;
+
+    $result = $this->mailManager->mail(self::MODULE_NAME, $key, $to, $langCode, $params,
+      NULL, $send);
+
+    $success = $result['result'] === TRUE;
+    if (!$success) {
+      $this->messenger->addError(t('There was a problem sending
+      confirmation message and it was not sent.'), 'error');
+    }
+    else {
+      $this->messenger->addStatus(t('Your message has been sent.'));
+    }
+
+    return $success;
+  }
+
+  /**
+   * Renders the email body.
+   */
+  private function renderEmailBody(string $themeKey, string $url, string $langCode, $formTitle = NULL) {
+    $render = [
+      '#theme' => $themeKey,
+      '#url' => $url,
+      '#title' => $formTitle,
+      '#language' => $langCode,
+    ];
+
+    $renderedEmail = $this->renderer->render($render);
+    // Remove possible twig debug tags.
+    $output = preg_replace(
+      "#<!--[^-]*(?:-(?!->)[^-]*)*-->#",
+      '',
+     $renderedEmail);
+
+    return $output;
+  }
+
+  /**
+   * Generates an url for a submission id.
+   */
+  private function generateSubmissionLink(string $submission_id) {
+    return Url::fromRoute(
+      'form_tool_share.view_submission',
+      ['submission_id' => $submission_id],
+      [
+        'attributes' => [
+          'data-drupal-selector' => 'form-submitted-ok',
+        ],
+        'absolute' => TRUE,
+      ]
+    );
+  }
+
+}

--- a/public/modules/custom/webform_formtool_handler/templates/submission-email-notify-submitter.html.twig
+++ b/public/modules/custom/webform_formtool_handler/templates/submission-email-notify-submitter.html.twig
@@ -1,0 +1,31 @@
+{% if language == 'fi' %}
+Hei!
+
+Lomakkeesi on katseltavissa
+Pääset katselemaan lähettämääsi lomaketta tunnistautumalla.
+
+Siirry lomakkeelle: {{url}}
+
+
+Ystävällisin terveisin,
+
+Helsingin Kaupunki
+Lomakepalvelu
+
+Tämä on automaattinen heräteviesti. Ethän vastaa tähän viestiin, sillä vastauksia ei käsitellä.
+{% elseif language == 'sv' %}
+Hej!
+
+Din blankett finns till påseende.
+Du kan titta på blanketten du skickade genom att identifiera dig.
+
+Gå till blanketten: {{ url }}
+
+
+Med vänlig hälsning,
+
+Helsingfors stad
+Blankettjänst
+
+Det här är ett automatiskt meddelande. Svara inte på det här meddelandet, för ditt svarsmeddelande kommer inte att behandlas.
+{% endif %}

--- a/public/modules/custom/webform_formtool_handler/templates/submission-email-notify.html.twig
+++ b/public/modules/custom/webform_formtool_handler/templates/submission-email-notify.html.twig
@@ -1,0 +1,28 @@
+{% if language == 'en' %}
+Hello!
+
+New {{ title }} submission has been received.
+
+Go to the submission page: {{url}}
+
+Best regards,
+
+City of Helsinki
+Form tool
+
+This is an automatic message. Please do not reply to this message.
+{% elseif language == 'fi' %}
+Hei!
+
+{{ title }} on saapunut käsiteltäväksi.
+
+Siirry lomakkeelle: {{ url }}
+
+
+Ystävällisin terveisin,
+
+Helsingin Kaupunki
+Lomakepalvelu
+
+Tämä on automaattinen heräteviesti. Ethän vastaa tähän viestiin, sillä vastauksia ei käsitellä.
+{% endif %}

--- a/public/modules/custom/webform_formtool_handler/translations/fi/fi.po
+++ b/public/modules/custom/webform_formtool_handler/translations/fi/fi.po
@@ -33,3 +33,9 @@ msgstr "Töysänkatu 2 D"
 msgctxt "Submission Print page for the MVP form"
 msgid "00510 Helsinki"
 msgstr "00510 Helsinki"
+
+msgid "Your form submission is viewable"
+msgstr "Lomakkeesi on katseltavissa"
+
+msgid "New submission for @title"
+msgstr "@title on saapunut käsiteltäväksi"

--- a/public/modules/custom/webform_formtool_handler/translations/sv/sv.po
+++ b/public/modules/custom/webform_formtool_handler/translations/sv/sv.po
@@ -33,3 +33,6 @@ msgstr "Töysägatan 2 D"
 msgctxt "Submission Print page for the MVP form"
 msgid "00510 Helsinki"
 msgstr "00510 Helsingfors"
+
+msgid "Your form submission is viewable"
+msgstr "Din blankett finns till påseende"

--- a/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
+++ b/public/modules/custom/webform_formtool_handler/webform_formtool_handler.module
@@ -34,6 +34,12 @@ function webform_formtool_handler_theme(): array {
         'language' => NULL,
       ],
     ],
+    'submission_email_notify' => [
+      'variables' => ['url' => NULL, 'title' => NULL, 'language' => NULL],
+    ],
+    'submission_email_notify_submitter' => [
+      'variables' => ['url' => NULL, 'title' => NULL, 'language' => NULL],
+    ],
   ];
 }
 
@@ -46,6 +52,12 @@ function webform_formtool_handler_mail($key, &$message, $params) {
   ];
 
   switch ($key) {
+    case 'submission_email_notify_submitter':
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['subject'] = t('Your form submission is viewable');
+      $message['body'][] = $params['message'];
+      break;
+
     case 'submission_email_notify':
       $message['from'] = \Drupal::config('system.site')->get('mail');
       $message['subject'] = t('New submission for @title', ['@title' => $params['form_title']], $options);

--- a/public/modules/custom/webform_formtool_handler/webform_formtool_handler.services.yml
+++ b/public/modules/custom/webform_formtool_handler/webform_formtool_handler.services.yml
@@ -10,3 +10,11 @@ services:
     arguments: [
         '@http_client'
     ]
+  webform_formtool_handler.submission_email_service:
+    class: Drupal\webform_formtool_handler\Service\SubmissionEmailService
+    arguments: [
+      '@language_manager',
+      '@plugin.manager.mail',
+      '@renderer',
+      '@messenger',
+    ]


### PR DESCRIPTION
# [LOM-392](https://helsinkisolutionoffice.atlassian.net/browse/LOM-392)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Email templates and language versions for submitter and controller

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-392-email-templates`
  * `make fresh`
* Run `make drush-cr`

* Make sure you have following lines in your local.settings.php, so you can use mailhog.
```
$config['smtp.settings']['smtp_host'] = "stonehenge";
$config['smtp.settings']['smtp_port'] = 1025;
```

https://mailhog.docker.so/

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as normal user and submit the form
* [ ] Check that 2 mails are sent to separate receivers (submitter & controller)
* [ ] Check that the content is right for each receiver.
* [ ] Submit the form in SV version and check that submitter gets SV version of the email.
* [ ] Controller should always get a Finnish version of the mail


* Link to other PR


[LOM-392]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ