### PR TITLE
LOM-420: Alter language switch links on 403 pages

### DIFF
--- a/public/modules/custom/form_tool_profile/form_tool_profile.module
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.module
@@ -168,3 +168,33 @@ function form_tool_profile_user_predelete(UserInterface $account) {
 
   }
 }
+
+/**
+ * Implements hook_language_switch_links_alter().
+ */
+function form_tool_profile_language_switch_links_alter(array &$links, $type, Url &$url) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $parent_request = \Drupal::requestStack()->getParentRequest();
+
+  if ($route_name === 'system.403' && $parent_request !== NULL) {
+    $node = $parent_request->get('node');
+
+    if (!$node) {
+      return;
+    }
+
+    foreach ($links as $langcode => &$link) {
+      $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], ['language' => $langcode]);
+      $lang = \Drupal::languageManager()->getLanguage($langcode);
+      try {
+        $node->getTranslation($langcode);
+      }
+      catch (Exception $e) {
+        $link['no_translation'] = TRUE;
+      }
+      $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], ['language' => $lang]);
+      $link['url'] = $url;
+      $link['altered'] = TRUE;
+    }
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
@@ -43,6 +43,7 @@
         {% set classes = ['language-link'] %}
         {% set ariaCurrent = null %}
         {% set title = null %}
+        {% set set_no_translation = false %}
 
         {# Check if link is part of alternative menu and set class accordingly. #}
         {% set classes = classes|merge([alternative_language ? 'is-alternative' : '']) %}
@@ -54,23 +55,17 @@
             {% set language_link = item["link"]["#url"]|render %}
           {% endif %}
           {% if item["link"]["#options"]["no_translation"] is defined %}
-            {% set element = 'span' %}
-            {% set language_link = '' %}
-            {% if lang == 'en' %}
-              {% set title = create_attribute({'title': 'There is no English translation for this page'}) %}
-            {% elseif lang == 'fi' %}
-              {% set title = create_attribute({'title': 'Tästä sivusta ei ole suomenkielistä käännöstä'}) %}
-            {% elseif lang == 'sv' %}
-              {% set title = create_attribute({'title': 'Det finns ingen svensk översättning för denna sida'}) %}
-            {% elseif lang == 'ru' %}
-              {% set title = create_attribute({'title': 'Для этой страницы нет русского перевода'}) %}
-            {% endif %}
+            {% set set_no_translation = true %}
           {% endif %}
         {% elseif lang == current_langcode %}
           {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
           {% set element = 'a' %}
           {% set ariaCurrent = create_attribute({'aria-current': 'true'}) %}
         {% else %}
+          {% set set_no_translation = true %}
+        {% endif %}
+
+        {% if set_no_translation == true %}
           {% set element = 'span' %}
           {% set classes = classes|merge(['is-disabled']) %}
           {% if lang == 'en' %}

--- a/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
@@ -1,0 +1,92 @@
+{#
+/**
+ * @file
+ * Theme override for a set of links.
+ *
+ * Available variables:
+ * - attributes: Attributes for the UL containing the list of links.
+ * - links: Links to be output.
+ *   Each link will have the following elements:
+ *   - title: The link text.
+ *   - href: The link URL. If omitted, the 'title' is shown as a plain text
+ *     item in the links list. If 'href' is supplied, the entire link is passed
+ *     to l() as its $options parameter.
+ *   - attributes: (optional) HTML attributes for the anchor, or for the <span>
+ *     tag if no 'href' is supplied.
+ * - heading: (optional) A heading to precede the links.
+ *   - text: The heading text.
+ *   - level: The heading level (e.g. 'h2', 'h3').
+ *   - attributes: (optional) A keyed list of attributes for the heading.
+ *   If the heading is a string, it will be used as the text of the heading and
+ *   the level will default to 'h2'.
+ *
+ *   Headings should be used on navigation menus and any list of links that
+ *   consistently appears on multiple pages. To make the heading invisible use
+ *   the 'visually-hidden' CSS class. Do not use 'display:none', which
+ *   removes it from screen readers and assistive technology. Headings allow
+ *   screen reader and keyboard only users to navigate to or skip the links.
+ *   See http://juicystudio.com/article/screen-readers-display-none.php and
+ *   http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ *
+ * @see template_preprocess_links()
+ */
+#}
+
+{% if links %}
+  <div {{ attributes.addClass('language-switcher', 'js-language-switcher') }}>
+    <div class="language-links">
+      {% for item in links %}
+        {% set language_link = '' %}
+        {% set lang = item.link['#options']['#abbreviation'] %}
+        {% set untranslated = item.link['#options']['#untranslated'] %}
+        {% set alternative_language = item.link['#options']['#alternative_language'] %}
+        {% set classes = ['language-link'] %}
+        {% set ariaCurrent = null %}
+        {% set title = null %}
+
+        {# Check if link is part of alternative menu and set class accordingly. #}
+        {% set classes = classes|merge([alternative_language ? 'is-alternative' : '']) %}
+
+        {% if not untranslated and not alternative_language and lang != current_langcode %}
+          {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
+          {% set element = 'a' %}
+          {% if item["link"]["#options"]["altered"] is defined %}
+            {% set language_link = item["link"]["#url"]|render %}
+          {% endif %}
+          {% if item["link"]["#options"]["no_translation"] is defined %}
+            {% set element = 'span' %}
+            {% set language_link = '' %}
+            {% if lang == 'en' %}
+              {% set title = create_attribute({'title': 'There is no English translation for this page'}) %}
+            {% elseif lang == 'fi' %}
+              {% set title = create_attribute({'title': 'Tästä sivusta ei ole suomenkielistä käännöstä'}) %}
+            {% elseif lang == 'sv' %}
+              {% set title = create_attribute({'title': 'Det finns ingen svensk översättning för denna sida'}) %}
+            {% elseif lang == 'ru' %}
+              {% set title = create_attribute({'title': 'Для этой страницы нет русского перевода'}) %}
+            {% endif %}
+          {% endif %}
+        {% elseif lang == current_langcode %}
+          {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
+          {% set element = 'a' %}
+          {% set ariaCurrent = create_attribute({'aria-current': 'true'}) %}
+        {% else %}
+          {% set element = 'span' %}
+          {% set classes = classes|merge(['is-disabled']) %}
+          {% if lang == 'en' %}
+            {% set title = create_attribute({'title': 'There is no English translation for this page'}) %}
+          {% elseif lang == 'fi' %}
+            {% set title = create_attribute({'title': 'Tästä sivusta ei ole suomenkielistä käännöstä'}) %}
+          {% elseif lang == 'sv' %}
+            {% set title = create_attribute({'title': 'Det finns ingen svensk översättning för denna sida'}) %}
+          {% elseif lang == 'ru' %}
+            {% set title = create_attribute({'title': 'Для этой страницы нет русского перевода'}) %}
+          {% endif %}
+        {% endif %}
+
+        {# Construct the element based on variables. #}
+        <{{element}} {{ create_attribute({'class': classes} ) }} {{ language_link ? create_attribute({'href': language_link} ) }} {{ create_attribute({'lang': lang} ) }} {{ ariaCurrent }} {{ title }}>{{ item.text|capitalize }}</{{element}}>
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
# [LOM-420](https://helsinkisolutionoffice.atlassian.net/browse/LOM-420)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Alter language links to show possible node translation, instead of translation of system.403 page when accessing forms that require authentication

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-420-http403-language-links`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] As logged in user visit https://hel-fi-form-tool.docker.so/fi/lomakkeet/todistusjaljennospyynto-tilaus
* [ ] Check that language links will direct you to language version instead of /403 page
* [ ] Remove translation (or create content without translations) and check that language block will tell that there is no translation available.


[LOM-420]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ