### PR TITLE
LOM-423: FormToolSubmission listener for sending notification to a se…

### DIFF
--- a/public/modules/custom/webform_formtool_handler/src/EventSubscriber/WebformSubmissionSubscriber.php
+++ b/public/modules/custom/webform_formtool_handler/src/EventSubscriber/WebformSubmissionSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\webform_formtool_handler\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\webform_formtool_handler\Event\WebformSubmissionEvent;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Subscribes to webform submission event and sends notification to service.
+ */
+class WebformSubmissionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a WebformSubmissionSubscriber listener.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   Http client. Guzzle.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $logger
+   *   Logger factory.
+   */
+  public function __construct(
+    private ClientInterface $http_client,
+    private LoggerChannelFactory $logger
+    ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[WebformSubmissionEvent::SUBMISSION_EVENT][] = ['onSubmissionCreate'];
+    return $events;
+  }
+
+  /**
+   * Send POST request to service.
+   *
+   * @param \Drupal\webform_formtool_handler\Event\WebformSubmissionEvent $event
+   *   A WebformSubmissionEvent event.
+   */
+  public function onSubmissionCreate(WebformSubmissionEvent $event) {
+
+    try {
+      $formToolSubmissionId = $event->getAtvDocument()->getId();
+      $endpoint = getenv('FORM_SUBMISSION_NOTIFICATION_ENDPOINT');
+      $password = getenv('FORM_SUBMISSION_NOTIFICATION_ENDPOINT_PASSWORD');
+
+      if (!$endpoint || !$password || !$formToolSubmissionId) {
+        return;
+      }
+
+      $response = $this->http_client->request('POST', $endpoint, [
+        'json' => [
+          'formID' => $formToolSubmissionId,
+        ],
+        'headers' => [
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json',
+          'Authorization' => 'Basic ' . $password,
+        ],
+      ]);
+
+      $statusCode = $response->getStatusCode();
+
+      $this->logger->get('webform_formtool_handler')->info('Sent notification for @submissionId (@statusCode)', [
+        '@submissionId' => $formToolSubmissionId,
+        '@statusCode' => $statusCode,
+      ]);
+    }
+    catch (\Exception $e) {
+      $this->logger->get('webform_formtool_handler')->error('Failed to send form submission notification event: ' . $e->getMessage());
+    }
+  }
+
+}

--- a/public/modules/custom/webform_formtool_handler/webform_formtool_handler.services.yml
+++ b/public/modules/custom/webform_formtool_handler/webform_formtool_handler.services.yml
@@ -18,3 +18,11 @@ services:
       '@renderer',
       '@messenger',
     ]
+  webform_formtool_handler.form_submission_listtner:
+    class: Drupal\webform_formtool_handler\EventSubscriber\WebformSubmissionSubscriber
+    arguments: [
+        '@http_client',
+        '@logger.factory',
+    ]
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
…rvice

# [LOM-423](https://helsinkisolutionoffice.atlassian.net/browse/LOM-423)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

POST request to service during form submission.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`
* Set FORM_SUBMISSION_NOTIFICATION_ENDPOINT env variable `putenv('FORM_SUBMISSION_NOTIFICATION_ENDPOINT=xxxx)`
* Set FORM_SUBMISSION_NOTIFICATION_ENDPOINT_PASSWORD env variable `putenv('FORM_SUBMISSION_NOTIFICATION_ENDPOINT_PASSWORD=xxxx)`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that request is sent (logs)
* [ ] Check that code follows our standards


[LOM-423]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ