### PR TITLE
LOM-366: Trigger cache kill switch before redirection

### DIFF
--- a/public/modules/custom/form_tool_profile/form_tool_profile.services.yml
+++ b/public/modules/custom/form_tool_profile/form_tool_profile.services.yml
@@ -1,6 +1,6 @@
 services:
   form_tool_profile.request_event_subscriber:
     class: '\Drupal\form_tool_profile\EventSubscriber\RequestEventSubscriber'
-    arguments: [ '@current_user', '@current_route_match', '@request_stack' ]
+    arguments: [ '@current_user', '@current_route_match', '@request_stack', '@page_cache_kill_switch' ]
     tags:
       - { name: 'event_subscriber'}


### PR DESCRIPTION
# [LOM-366](https://helsinkisolutionoffice.atlassian.net/browse/LOM-366)

## What was done
<!-- Describe what was done -->

Fixes problem with the implementation. Trigger cache kill switch.

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Comment out `$settings['cache'}['bins']*` from you `local.settings.php` and make `drush-cr`
* [ ] As anon user, clicking "Kirjaudu" should always redirect you to the todistusjaljennospyynto-tilaus login, instead only once per cache clear.




[LOM-366]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ