### PR TITLE
LOM-438: Remove {empty} text from submission results

### DIFF
--- a/conf/cmi/webform.settings.yml
+++ b/conf/cmi/webform.settings.yml
@@ -112,7 +112,7 @@ form:
   filter_state: ''
 element:
   machine_name_pattern: a-z0-9_
-  empty_message: '{Empty}'
+  empty_message: ''
   allowed_tags: admin
   wrapper_classes: |
     container-inline clearfix


### PR DESCRIPTION
# [LOM-438](https://helsinkisolutionoffice.atlassian.net/browse/LOM-438
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-438-remove-empty-text`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill the form, but leave "Lisätiedot" field empty
* [ ] Submit form and view the submission and check that the "Lisätiedot" field doesn't have `{empty}` as output


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[LOM-438]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ