### PR TITLE
fix: LOM-439: Fix typo in Todistusjäljennöspyyntö

### DIFF
--- a/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -77,7 +77,7 @@ elements: |-
       '#required': true
     todistuksen_antanut_helsinkilainen_koulu:
       '#type': textfield
-      '#title': 'Todistuksen antanut Helsinkiläinen koulu'
+      '#title': 'Todistuksen antanut helsinkiläinen koulu'
       '#description': 'Anna koulun nimi siin&auml; muodossa, mik&auml; se on ollut opiskellessasi.'
       '#required': true
       '#counter_type': character


### PR DESCRIPTION
# [LOM-439](https://helsinkisolutionoffice.atlassian.net/browse/LOM-439)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix typo in Todistusjäljennöspyyntö

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-439-kirjoitusvirhe-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Todistuksen antanut Helsinkiläinen koulu is now Todistuksen antanut helsinkiläinen koulu

[LOM-439]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ