### PR TITLE
fix: LOM-449: Added conditional privacy policy link

### DIFF
--- a/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -22,9 +22,11 @@ elements: |
     '#email__title': ''
   mahdolliset_lisatiedot:
     '#title': 'Om ditt namn eller din personbeteckning har ändrats, ange här namn och personbeteckning för tidpunkten då betyget utfärdades.'
+  tutustu_rekisteriselosteeseen:
+    '#title': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administration%20av%20grundl%C3%A4ggande%20utbildning.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'
+  tutustu_rekisteriselosteeseen_lukio:
+    '#title': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administrationen%20av%20studier%20inom%20gymnasieutbildningen.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'
   olen_tutustunut_rekisteriselosteeseen:
     '#title': 'Jag har läst registerbeskrivningen'
-    '#description': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administration%20av%20grundl%C3%A4ggande%20utbildning.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'
   olen_tutustunut_rekisteriselosteeseen_lukio:
     '#title': 'Jag har läst registerbeskrivningen'
-    '#description': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administrationen%20av%20studier%20inom%20gymnasieutbildningen.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'

--- a/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -28,5 +28,3 @@ elements: |
     '#title': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administrationen%20av%20studier%20inom%20gymnasieutbildningen.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'
   olen_tutustunut_rekisteriselosteeseen:
     '#title': 'Jag har läst registerbeskrivningen'
-  olen_tutustunut_rekisteriselosteeseen_lukio:
-    '#title': 'Jag har läst registerbeskrivningen'

--- a/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -22,3 +22,9 @@ elements: |
     '#email__title': ''
   mahdolliset_lisatiedot:
     '#title': 'Om ditt namn eller din personbeteckning har ändrats, ange här namn och personbeteckning för tidpunkten då betyget utfärdades.'
+  olen_tutustunut_rekisteriselosteeseen:
+    '#title': 'Jag har läst registerbeskrivningen'
+    '#description': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administration%20av%20grundl%C3%A4ggande%20utbildning.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'
+  olen_tutustunut_rekisteriselosteeseen_lukio:
+    '#title': 'Jag har läst registerbeskrivningen'
+    '#description': 'L&auml;s mer om <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Register%20f%C3%B6r%20administrationen%20av%20studier%20inom%20gymnasieutbildningen.pdf" target="_blank">registerbeskrivningen</a> (l&auml;nken &ouml;ppnas i en ny flik)'

--- a/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -109,10 +109,39 @@ elements: |-
   rekisteriseloste:
     '#type': webform_section
     '#title': Rekisteriseloste
+    valitse_ensin_tilattava_todistus_:
+      '#type': label
+      '#title': 'Valitse ensin tilattava todistus.'
+      '#states':
+        visible:
+          ':input[name="valitse_tilattava_todistus"]':
+            unchecked: true
+    tutustu_rekisteriselosteeseen:
+      '#type': label
+      '#title': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Perusopetuksen%20opintohallinnon%20rekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen välilehteen)'
+      '#states':
+        visible:
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Peruskoulun päättötodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Peruskoulun erotodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lisäopetuksen 10.lk todistus'
+    tutustu_rekisteriselosteeseen_lukio:
+      '#type': label
+      '#title': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Lukiokoulutuksen%20opintohallintorekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen välilehteen)'
+      '#states':
+        visible:
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lukion päättötodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lukion erotodistus'
     olen_tutustunut_rekisteriselosteeseen:
       '#type': checkbox
-      '#title': 'Olen tutustunut rekisteriselosteeseen'
-      '#description': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Perusopetuksen%20opintohallinnon%20rekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen v&auml;lilehteen)'
+      '#title': 'Olen tutustunut rekisteriselosteeseen *'
       '#description_display': before
       '#required': true
       '#states':
@@ -127,8 +156,7 @@ elements: |-
               value: 'Lisäopetuksen 10.lk todistus'
     olen_tutustunut_rekisteriselosteeseen_lukio:
       '#type': checkbox
-      '#title': 'Olen tutustunut rekisteriselosteeseen'
-      '#description': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Lukiokoulutuksen%20opintohallintorekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen v&auml;lilehteen)'
+      '#title': 'Olen tutustunut rekisteriselosteeseen *'
       '#description_display': before
       '#required': true
       '#states':

--- a/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -146,26 +146,8 @@ elements: |-
       '#required': true
       '#states':
         visible:
-          - ':input[name="valitse_tilattava_todistus"]':
-              value: 'Peruskoulun päättötodistus'
-          - or
-          - ':input[name="valitse_tilattava_todistus"]':
-              value: 'Peruskoulun erotodistus'
-          - or
-          - ':input[name="valitse_tilattava_todistus"]':
-              value: 'Lisäopetuksen 10.lk todistus'
-    olen_tutustunut_rekisteriselosteeseen_lukio:
-      '#type': checkbox
-      '#title': 'Olen tutustunut rekisteriselosteeseen *'
-      '#description_display': before
-      '#required': true
-      '#states':
-        visible:
-          - ':input[name="valitse_tilattava_todistus"]':
-              value: 'Lukion päättötodistus'
-          - or
-          - ':input[name="valitse_tilattava_todistus"]':
-              value: 'Lukion erotodistus'
+          ':input[name="valitse_tilattava_todistus"]':
+            checked: true
   actions:
     '#type': webform_actions
     '#title': 'Paina nappia'

--- a/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -68,6 +68,7 @@ elements: |-
     valitse_tilattava_todistus:
       '#type': radios
       '#title': 'Valitse tilattava todistus'
+      '#description': 'Valinta vaikuttaa rekisteriselosteesen, joka pit&auml;&auml; hyv&auml;ksy&auml;.'
       '#options':
         'Peruskoulun päättötodistus': 'Peruskoulun päättötodistus'
         'Peruskoulun erotodistus': 'Peruskoulun erotodistus'
@@ -105,6 +106,38 @@ elements: |-
       '#counter_minimum': 1
       '#counter_maximum': 750
       '#counter_maximum_message': ' '
+  rekisteriseloste:
+    '#type': webform_section
+    '#title': Rekisteriseloste
+    olen_tutustunut_rekisteriselosteeseen:
+      '#type': checkbox
+      '#title': 'Olen tutustunut rekisteriselosteeseen'
+      '#description': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Perusopetuksen%20opintohallinnon%20rekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen v&auml;lilehteen)'
+      '#description_display': before
+      '#required': true
+      '#states':
+        visible:
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Peruskoulun päättötodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Peruskoulun erotodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lisäopetuksen 10.lk todistus'
+    olen_tutustunut_rekisteriselosteeseen_lukio:
+      '#type': checkbox
+      '#title': 'Olen tutustunut rekisteriselosteeseen'
+      '#description': 'Tutustu <a href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kasko/Lukiokoulutuksen%20opintohallintorekisteri.pdf" target="_blank">rekisteriselosteeseen</a> (linkki avautuu uuteen v&auml;lilehteen)'
+      '#description_display': before
+      '#required': true
+      '#states':
+        visible:
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lukion päättötodistus'
+          - or
+          - ':input[name="valitse_tilattava_todistus"]':
+              value: 'Lukion erotodistus'
   actions:
     '#type': webform_actions
     '#title': 'Paina nappia'

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -8,6 +8,7 @@
 use Drupal\user\Entity\Role;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Entity\User;
+use Drupal\webform\Entity\Webform;
 
 /**
  * Privacy policy things?

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -8,7 +8,11 @@
 use Drupal\user\Entity\Role;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Entity\User;
+
+/*
+Comment out because the function using this is commented out.
 use Drupal\webform\Entity\Webform;
+ */
 
 /**
  * Privacy policy things?

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -8,7 +8,6 @@
 use Drupal\user\Entity\Role;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Entity\User;
-use Drupal\webform\Entity\Webform;
 
 /**
  * Privacy policy things?
@@ -74,35 +73,41 @@ function _form_tool_webform_parameters_get_default_privacy_policy_link(array $fo
  */
 function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Commented out temporarily (?)
-  /*if (!Drupal::service('router.admin_context')->isAdminRoute()) {
-    if (array_key_exists('#webform_id', $form)) {
-      $webform = Webform::load($form['#webform_id']);
-      $formsettings = $webform->getThirdPartySettings('form_tool_webform_parameters');
+  /* if (!Drupal::service('router.admin_context')->isAdminRoute()) {
+  if (array_key_exists('#webform_id', $form)) {
+  $webform = Webform::load($form['#webform_id']);
+  $formsettings =
+  $webform->getThirdPartySettings('form_tool_webform_parameters');
 
-      $privacy_policy_string = t('Read more about <a href="@privacy-policy-link" class="privacy-policy-link" target="_blank">the privacy policy</a> (the link will open in a new tab).', [
-        '@privacy-policy-link' => _form_tool_webform_parameters_get_default_privacy_policy_link($formsettings),
-      ]);
-      $form['elements']['privacy_policy_wrapper'] = [
-        '#type' => 'webform_section',
-        '#title' => t('Privacy Policy'),
-      ];
-      $form['elements']['privacy_policy_wrapper']['privacy_policy_link'] = [
-        '#type' => 'label',
-        '#title' => $privacy_policy_string,
-      ];
-      $form['elements']['privacy_policy_wrapper']['privacy_policy_acceptance'] = [
-        '#type' => 'checkbox',
-        '#title' => t('I have read the privacy policy'),
-        '#required' => TRUE,
-      ];
-      if (array_key_exists('elements', $form)) {
-        $temp = $form['elements']['actions'];
-        unset($form['elements']['actions']);
-        $form['elements']['actions'] = $temp;
-      }
-    }
+  $privacy_policy_string =
+  t('Read more about
+  <a href="@privacy-policy-link" class="privacy-policy-link" target="_blank">
+  the privacy policy</a>
+  (the link will open in a new tab).', [
+  '@privacy-policy-link' =>
+  _form_tool_webform_parameters_get_default_privacy_policy_link($formsettings),
+  ]);
+  $form['elements']['privacy_policy_wrapper'] = [
+  '#type' => 'webform_section',
+  '#title' => t('Privacy Policy'),
+  ];
+  $form['elements']['privacy_policy_wrapper']['privacy_policy_link'] = [
+  '#type' => 'label',
+  '#title' => $privacy_policy_string,
+  ];
+  $form['elements']['privacy_policy_wrapper']['privacy_policy_acceptance'] = [
+  '#type' => 'checkbox',
+  '#title' => t('I have read the privacy policy'),
+  '#required' => TRUE,
+  ];
+  if (array_key_exists('elements', $form)) {
+  $temp = $form['elements']['actions'];
+  unset($form['elements']['actions']);
+  $form['elements']['actions'] = $temp;
+  }
+  }
 
-  }*/
+  } */
   if ($form_id == 'webform_settings_form' || $form_id == 'webform_add_form' || $form_id == 'webform_duplicate_form') {
 
     $bundle = $form_state->getFormObject()->getEntity();

--- a/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
+++ b/public/modules/custom/form_tool_webform_parameters/form_tool_webform_parameters.module
@@ -73,7 +73,8 @@ function _form_tool_webform_parameters_get_default_privacy_policy_link(array $fo
  * Implememts hook_form_alter()
  */
 function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (!Drupal::service('router.admin_context')->isAdminRoute()) {
+  // Commented out temporarily (?)
+  /*if (!Drupal::service('router.admin_context')->isAdminRoute()) {
     if (array_key_exists('#webform_id', $form)) {
       $webform = Webform::load($form['#webform_id']);
       $formsettings = $webform->getThirdPartySettings('form_tool_webform_parameters');
@@ -101,7 +102,7 @@ function form_tool_webform_parameters_form_alter(&$form, FormStateInterface $for
       }
     }
 
-  }
+  }*/
   if ($form_id == 'webform_settings_form' || $form_id == 'webform_add_form' || $form_id == 'webform_duplicate_form') {
 
     $bundle = $form_state->getFormObject()->getEntity();


### PR DESCRIPTION
# [LOM-449](https://helsinkisolutionoffice.atlassian.net/browse/LOM-449)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added conditional privacy policy link

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-449-privacy-policy`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that when selected Peruskoulu or 10lk, you see perusopetus-privacy policy and when selected lukio you see lukio-privacy policy


[LOM-449]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ