### PR TITLE
LOM-461: Change logout urls to check if they need a prefixed address

### DIFF
--- a/public/modules/custom/autologout_extend/js/autologout.js
+++ b/public/modules/custom/autologout_extend/js/autologout.js
@@ -226,14 +226,14 @@
 
       function logout() {
         if (localSettings.use_alt_logout_method) {
-          var logoutUrl = drupalSettings.path.baseUrl + "autologout_alt_logout";
+          var logoutUrl = getAjaxPath("autologout_alt_logout");
           triggerLogoutEvent('alternative', logoutUrl);
 
           window.location = logoutUrl;
         }
         else {
           $.ajax({
-            url: drupalSettings.path.baseUrl + "autologout_ajax_logout",
+            url: getAjaxPath("autologout_ajax_logout"),
             type: "POST",
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-Requested-With', {

--- a/public/modules/custom/webform_formtool_handler/templates/submission-email-notify-submitter.html.twig
+++ b/public/modules/custom/webform_formtool_handler/templates/submission-email-notify-submitter.html.twig
@@ -1,7 +1,7 @@
 {% if language == 'fi' %}
 Hei!
 
-Lomakkeesi on katseltavissa
+Lomakkeesi on katseltavissa.
 Pääset katselemaan lähettämääsi lomaketta tunnistautumalla.
 
 Siirry lomakkeelle: {{url}}


### PR DESCRIPTION
# [LOM-461](https://helsinkisolutionoffice.atlassian.net/browse/LOM-461)

## What was done

Add function call to check if path prefix should be added to log out url.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-461-autologout-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Clicking no or the x on autologout module should log user out, instead of refreshing the modal

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[LOM-461]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ