### PR TITLE
fix: LOM-440: autologout translations

### DIFF
--- a/conf/cmi/autologout.settings.yml
+++ b/conf/cmi/autologout.settings.yml
@@ -1,17 +1,17 @@
 _core:
   default_config_hash: pYO-DH32fm7GYMJrNx5syvfx2n-5s88kvuddFKXC758
 enabled: true
-timeout: 1800
+timeout: 900
 max_timeout: 172800
-padding: 60
+padding: 300
 logout_regardless_of_activity: false
 no_individual_logout_threshold: true
 role_logout: false
 role_logout_max: false
 redirect_url: /
 no_dialog: false
-message: 'Your session is about to expire. Do you want to reset it?'
-inactivity_message: 'You have been logged out due to inactivity.'
+message: 'Your session is about to end. Do you want to continue?'
+inactivity_message: 'Your session is about to end. Do you want to continue?'
 inactivity_message_type: status
 modal_width: 450
 enforce_admin: false
@@ -19,10 +19,10 @@ jstimer_format: '%hours%:%mins%:%secs%'
 jstimer_js_load_option: false
 use_alt_logout_method: false
 use_watchdog: true
-dialog_title: 'Lomeketyökalu Alert'
+dialog_title: 'The session is about to end'
 disable_buttons: false
-yes_button: ''
-no_button: ''
+yes_button: 'Continue session'
+no_button: 'Log out'
 whitelisted_ip_addresses: ''
 cookie_secure: true
 cookie_samesite: Lax

--- a/conf/cmi/language/fi/autologout.settings.yml
+++ b/conf/cmi/language/fi/autologout.settings.yml
@@ -1,0 +1,5 @@
+dialog_title: 'Istunto on päättymässä'
+yes_button: 'Jatka käyttöä'
+no_button: 'Kirjaudu ulos'
+message: 'Istuntosi on päättymässä. Haluatko jatkaa?'
+inactivity_message: 'Istuntosi on päättymässä. Haluatko jatkaa?'

--- a/conf/cmi/language/sv/autologout.settings.yml
+++ b/conf/cmi/language/sv/autologout.settings.yml
@@ -1,0 +1,5 @@
+dialog_title: 'Sessionen håller på att gå ut'
+yes_button: Fortsätta
+no_button: 'Logga ut'
+message: 'Din session håller på att gå ut. Vill du fortsätta?'
+inactivity_message: 'Din session håller på att gå ut. Vill du fortsätta?'


### PR DESCRIPTION
# [LOM-440](https://helsinkisolutionoffice.atlassian.net/browse/LOM-440)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change translations in autologout modal

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-440-autologout-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Wait for autologout and see what modal says

[LOM-440]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ