### PR TITLE
LOM-472: Fix formId if appEnv is prod

### DIFF
--- a/public/modules/custom/webform_formtool_handler/src/Plugin/WebformHandler/FormToolWebformHandler.php
+++ b/public/modules/custom/webform_formtool_handler/src/Plugin/WebformHandler/FormToolWebformHandler.php
@@ -269,6 +269,10 @@ class FormToolWebformHandler extends WebformHandlerBase {
 
     $appParam = self::getAppEnv();
 
+    if ($appParam === '') {
+      return 'HEL-' . strtoupper($thirdPartySettings['form_code']) . '-' . sprintf('%08d', $submission->id());
+    }
+
     return 'HEL-' . strtoupper($thirdPartySettings['form_code']) . '-' . sprintf('%08d', $submission->id()) . '-' . $appParam;
 
   }


### PR DESCRIPTION
# [LOM-472](https://helsinkisolutionoffice.atlassian.net/browse/LOM-472)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Removed extra `-` from form id @ production

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-472-formid-prod`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check in production or configure local env to drop env info somehow
* [ ] Check that code follows our standards

