### PR TITLE
fix: LOM-456: Show pickup address in radio button

### DIFF
--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Element/FormToolContactInfo.php
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/src/Element/FormToolContactInfo.php
@@ -65,7 +65,7 @@ class FormToolContactInfo extends WebformCompositeBase {
     ];
     $elements['Toimitustapa: Nouto'] = [
       '#type' => 'checkbox',
-      '#title' => t('Pickup'),
+      '#title' => t("Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."),
       '#title_display' => 'before',
     ];
     $elements['delivery_method'] = [
@@ -76,7 +76,7 @@ class FormToolContactInfo extends WebformCompositeBase {
         'email' => t('Email Address'),
         'postal' => t('Postal Delivery'),
         'cod' => t('Cash on Delivery'),
-        'pickup' => t('Pick Up'),
+        'pickup' => t("Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."),
       ],
       '#required' => TRUE,
       '#after_build' => [[get_called_class(), 'deliveryOptions']],
@@ -202,11 +202,6 @@ class FormToolContactInfo extends WebformCompositeBase {
         ],
       ],
     ];
-    $elements['pickup'] = [
-      '#type' => 'item',
-      '#markup' => 'Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta. Töysänkatu 2 D, 00510 Helsinki.',
-      '#after_build' => [[get_called_class(), 'pickup']],
-    ];
     $elements['email'] = [
       '#type' => 'textfield',
       '#title' => t('Email Address'),
@@ -216,10 +211,6 @@ class FormToolContactInfo extends WebformCompositeBase {
     $elements['Postiennakko -teksti'] = [
       '#type' => 'item',
       '#title' => t('Cash on delivery price is 9,20 €'),
-    ];
-    $elements['Nouto -teksti'] = [
-      '#type' => 'textfield',
-      '#title' => t('Pick-up from Töysänkatu 2 D, 00510 Helsinki.'),
     ];
 
     return $elements;
@@ -343,10 +334,6 @@ class FormToolContactInfo extends WebformCompositeBase {
     }
     $element['delivery_method']['#title'] = $element['#title'];
     unset($element['Toimitustapa: Nouto']);
-    if ($element['Nouto -teksti']['#title'] != '') {
-      $element['pickup']['#markup'] = $element['Nouto -teksti']['#title'];
-    }
-    unset($element['Nouto -teksti']);
     if ($element['Postiennakko -teksti']['#title'] != '') {
       $element['cod']['#markup'] = $element['Postiennakko -teksti']['#title'];
     }
@@ -369,7 +356,7 @@ class FormToolContactInfo extends WebformCompositeBase {
     ];
     $elements['Toimitustapa: Nouto'] = [
       '#type' => 'checkbox',
-      '#title' => t('Pickup'),
+      '#title' => t("Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."),
       '#title_display' => 'before',
     ];
 

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
@@ -46,8 +46,8 @@ msgstr "Puhelinnumero"
 msgid "Cash on delivery price is 9,20 €"
 msgstr "Postiennakon hinta asiakirjan tilaajalle 9,20 €"
 
-msgid "Pick-up from Töysänkatu 2 D, 00510 Helsinki."
-msgstr "Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta. Töysänkatu 2 D, 00510 Helsinki."
+msgid "Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."
+msgstr "Nouto. Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta. Töysänkatu 2 D, 00510 Helsinki."
 
 msgctxt "Notification inside a webform"
 msgid "Notification"

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/sv/sv.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/sv/sv.po
@@ -4,3 +4,6 @@ msgstr ""
 msgctxt "Notification inside a webform"
 msgid "Notification"
 msgstr "Meddelande"
+
+msgid "Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."
+msgstr "Upphämtning. Hämtas från fostrans- och utbildningssektorns arkiv. Töysänkatu 2 D, 00510 Helsinki."


### PR DESCRIPTION
# [LOM-456](https://helsinkisolutionoffice.atlassian.net/browse/LOM-456)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Show pickup address in radio button

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-456-toimitustapa-nouto`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that you see the pickup address in radio button
* [ ] Check that everything works

[LOM-456]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ