### PR TITLE
Feature/lom 458 autologout end profiili session

### DIFF
--- a/public/modules/custom/autologout_extend/autologout_extend.module
+++ b/public/modules/custom/autologout_extend/autologout_extend.module
@@ -5,6 +5,8 @@
  * Automated Logout extend - Module.
  */
 
+use Drupal\Core\Url;
+
 /**
  * Implements hook_page_attachments_alter().
  */
@@ -21,6 +23,10 @@ function autologout_extend_page_attachments_alter(array &$attachments) {
   if (!$openid_expire) {
     return;
   }
+
+  $redirect_logout_url = Url::fromRoute('user.logout');
+
+  $attachments['#attached']['drupalSettings']['autologout']['redirect_url'] = $redirect_logout_url->toString();
 
   $session_time_left = $openid_expire - REQUEST_TIME;
   $time_remaining_threshold = \Drupal::config('autologout_extend.settings')

--- a/public/modules/custom/autologout_extend/autologout_extend.services.yml
+++ b/public/modules/custom/autologout_extend/autologout_extend.services.yml
@@ -8,3 +8,7 @@ services:
     ]
     tags:
       - { name: event_subscriber }
+  autologout_extend.route_subscriber:
+    class: 'Drupal\autologout_extend\EventSubscriber\RouteSubscriber'
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/autologout_extend/src/Controller/LogoutController.php
+++ b/public/modules/custom/autologout_extend/src/Controller/LogoutController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\autologout_extend\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Returns responses for autologout module routes.
+ */
+class LogoutController extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('autologout.manager'),
+      $container->get('datetime.time')
+    );
+  }
+
+  /**
+   * Alternative logout.
+   */
+  public function altLogout() {
+    $url = Url::fromRoute('user.logout');
+    return new RedirectResponse($url->toString());
+  }
+
+  /**
+   * AJAX logout.
+   */
+  public function ajaxLogout() {
+    $response = new AjaxResponse();
+    $response->setStatusCode(200);
+    return $response;
+  }
+}

--- a/public/modules/custom/autologout_extend/src/Controller/LogoutController.php
+++ b/public/modules/custom/autologout_extend/src/Controller/LogoutController.php
@@ -39,4 +39,5 @@ class LogoutController extends ControllerBase {
     $response->setStatusCode(200);
     return $response;
   }
+
 }

--- a/public/modules/custom/autologout_extend/src/EventSubscriber/RouteSubscriber.php
+++ b/public/modules/custom/autologout_extend/src/EventSubscriber/RouteSubscriber.php
@@ -14,9 +14,11 @@ class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
-    // Change the route associated with the user profile page (/user, /user/{uid}).
     if ($route = $collection->get('autologout.ajax_logout')) {
-      $route->setDefault('_controller', '\Drupal\autologout_extend\Controller\LogoutController::ajaxLogout');
+      $route->setDefault(
+        '_controller',
+        '\Drupal\autologout_extend\Controller\LogoutController::ajaxLogout'
+      );
     }
   }
 

--- a/public/modules/custom/autologout_extend/src/EventSubscriber/RouteSubscriber.php
+++ b/public/modules/custom/autologout_extend/src/EventSubscriber/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\autologout_extend\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Change the route associated with the user profile page (/user, /user/{uid}).
+    if ($route = $collection->get('autologout.ajax_logout')) {
+      $route->setDefault('_controller', '\Drupal\autologout_extend\Controller\LogoutController::ajaxLogout');
+    }
+  }
+
+}


### PR DESCRIPTION
# [LOM-458](https://helsinkisolutionoffice.atlassian.net/browse/LOM-458)
<!-- What problem does this solve? -->

## What was done

Autologout to use user.logout path, as openid_connect handles both drupal + profiili logout.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-458-autologout-end-profiili-session`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with helsinki profiili
* [ ] Wait for logout modal and press log out button / or wait automatic action.
* [ ] Check that user is redirected to profiili's end session end point
* [ ] Check that Drupal session has been terminated.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
