### PR TITLE
fix: LOM-496: re-style status message

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/misc/status-messages.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/misc/status-messages.html.twig
@@ -55,27 +55,25 @@
     <div role="contentinfo" aria-labelledby="{{ title_ids[type] }}" class="{{ classes|without('messages-list__item')|join(' ') }}">
       {% if is_message_with_title or is_message_with_icon %}
         {% if is_message_with_title %}
-          <div class="hds-notification__label" role="heading" aria-level="2">
-            {% include "@hdbt/misc/icon.twig" with {icon: notification_icon} %}
-            <span id="{{ title_ids[type] }}">{{ status_headings[type] }}</span>
-          </div>
+          {% if messages|length > 1 %}
+            {% for message in messages %}
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                {% include "@hdbt/misc/icon.twig" with {icon: notification_icon} %}
+                <span id="{{ title_ids[type] }}">{{ message }}</span>
+              </div>
+            {% endfor %}
+          {% else %}
+            <div class="hds-notification__label" role="heading" aria-level="2">
+              {% include "@hdbt/misc/icon.twig" with {icon: notification_icon} %}
+              <span id="{{ title_ids[type] }}">{{ messages|first }}</span>
+            </div>
+          {% endif %}
         {% else %}
           <div class="hds-notification__label" role="heading" aria-hidden="true">
             {% include "@hdbt/misc/icon.twig" with {icon: notification_icon} %}
           </div>
         {% endif %}
       {% endif %}
-      <div class="hds-notification__body">
-        {% if messages|length > 1 %}
-          <ul class="messages__list">
-            {% for message in messages %}
-              <li class="messages__item">{{ message }}</li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          {{ messages|first }}
-        {% endif %}
-      </div>
     </div>
     {# Remove type specific classes. #}
     {% if attributes.toast %}


### PR DESCRIPTION
# [LOM-496](https://helsinkisolutionoffice.atlassian.net/browse/LOM-496)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved status message to status title
* Did not change the text bc it comes from helsinki profiili module

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-496-status-message`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that login status message looks as such

![image](https://github.com/City-of-Helsinki/drupal-helfi-form-tool/assets/26737690/2fac1f1a-ab01-4630-b2d9-c1c86f5bd8b7)


[LOM-496]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ