### PR TITLE
LOM-506: Patch languagemanager as backport is breaking our link alters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,8 @@
             },
             "drupal/core": {
                 "Add ability to delete all from tempstore": "https://www.drupal.org/files/issues/2020-10-23/get_delete_all_temp-2475719-31.patch",
-                "Fix session cookie error": "https://www.drupal.org/files/issues/2021-12-22/3255711-invalidate_session_on_destroy_session_manager-4.patch"
+                "Fix session cookie error": "https://www.drupal.org/files/issues/2021-12-22/3255711-invalidate_session_on_destroy_session_manager-4.patch",
+                "Lanaguage manager alter": "patches/core_language_manager.patch"
             },
             "drupal/openid_connect": {
                 "Open Id connect patch": "public/modules/custom/openid_logout_redirect/patches/hel_openid_connect_redirect.patch"

--- a/patches/core_language_manager.patch
+++ b/patches/core_language_manager.patch
@@ -1,0 +1,47 @@
+diff --git a/core/modules/language/src/ConfigurableLanguageManager.php b/core/modules/language/src/ConfigurableLanguageManager.php
+index c4187aaf60..b72f9b3709 100644
+--- a/core/modules/language/src/ConfigurableLanguageManager.php
++++ b/core/modules/language/src/ConfigurableLanguageManager.php
+@@ -410,27 +410,25 @@ public function getLanguageSwitchLinks($type, Url $url) {
+         if ($reflector->implementsInterface('\Drupal\language\LanguageSwitcherInterface')) {
+           $original_languages = $this->negotiatedLanguages;
+           $result = $this->negotiator->getNegotiationMethodInstance($method_id)->getLanguageSwitchLinks($this->requestStack->getCurrentRequest(), $type, $url);
++          $result = array_filter($result, function (array $link): bool {
++            $url = $link['url'] ?? NULL;
++            $language = $link['language'] ?? NULL;
++            if ($language instanceof LanguageInterface) {
++              $this->negotiatedLanguages[LanguageInterface::TYPE_CONTENT] = $language;
++              $this->negotiatedLanguages[LanguageInterface::TYPE_INTERFACE] = $language;
++            }
++            try {
++              return $url instanceof Url && $url->access();
++            }
++            catch (\Exception $e) {
++              return FALSE;
++            }
++          });
++          $this->negotiatedLanguages = $original_languages;
+ 
+           if (!empty($result)) {
+             // Allow modules to provide translations for specific links.
+             $this->moduleHandler->alter('language_switch_links', $result, $type, $url);
+-
+-            $result = array_filter($result, function (array $link): bool {
+-              $url = $link['url'] ?? NULL;
+-              $language = $link['language'] ?? NULL;
+-              if ($language instanceof LanguageInterface) {
+-                $this->negotiatedLanguages[LanguageInterface::TYPE_CONTENT] = $language;
+-                $this->negotiatedLanguages[LanguageInterface::TYPE_INTERFACE] = $language;
+-              }
+-              try {
+-                return $url instanceof Url && $url->access();
+-              }
+-              catch (\Exception $e) {
+-                return FALSE;
+-              }
+-            });
+-            $this->negotiatedLanguages = $original_languages;
+-
+             $links = (object) ['links' => $result, 'method_id' => $method_id];
+             break;
+           }


### PR DESCRIPTION
# [LOM-506](https://helsinkisolutionoffice.atlassian.net/browse/LOM-506)
<!-- What problem does this solve? -->

## What was done

Patch core language manager, as 9.5.9 introduced a backported change, which breaks our link alters.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout LOM-506-language-link-visibility`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that language links are visible, when you are logged out




[LOM-506]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ