### PR TITLE
fix: LOM-511: Todistuksen antamisvuosi steps added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ public/sites/default/local.settings.php
 !*.gitkeep
 !*.keepme
 .phpunit.*
+
+# Ignore some Robot framework files
+test/logit/*
+test/tests/Draft*

--- a/test/resources/variables/lomake-Variables.robot
+++ b/test/resources/variables/lomake-Variables.robot
@@ -88,7 +88,8 @@ ${lomake-tjpt-vtt-lukion-paattotodistus-radiobutton-FI}         //label[contains
 ${lomake-tjpt-vtt-lukion-erotodistus-radiobutton-FI}            //label[contains(.,'Lukion erotodistus')]
 # Todistuksen antanut Helsinkiläinen koulu
 ${lomake-koulun-nimi-input}                                     //input[@data-drupal-selector='edit-todistuksen-antanut-helsinkilainen-koulu']
-
+# Todistuksen antamisvuosi
+${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}               //input[@data-drupal-selector='edit-todistuksen-antamisvuosi']
 # Toimitustapa
 ${lomake-tjpt-toimitustapa-postiennakko-radiobutton-FI}         //label[contains(.,'Postiennakko')]
 ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}                //label[contains(.,'Nouto')]

--- a/test/tests/SMOKE-lomake-test-set.robot
+++ b/test/tests/SMOKE-lomake-test-set.robot
@@ -54,6 +54,9 @@ Fill and send form
     # Lisää koulun nimi
     Input Text                                              ${lomake-koulun-nimi-input}                                 SMOKE testi koulun nimi kenttä
     Capture Page Screenshot
+    # Lisää todistuksen antamisvuosi
+    Input Text                                              ${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}           2005      
+    Capture Page Screenshot
     # Valitse toimitustavaksi nouto
     Click Element                                           ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}
     Wait Until Page Contains                                Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta   20

--- a/test/tests/lomake-Check-tjpt-page-functionality-and-check-lomake.robot
+++ b/test/tests/lomake-Check-tjpt-page-functionality-and-check-lomake.robot
@@ -15,6 +15,7 @@ Force Tags      regression
 *** Variables ***
 
 ${lomake-testdata-koulunnimi}                               Mauri Makkaran ala-aste
+${lomake-testdata-todistuksen-antamisvuosi}                 2001
 ${lomake-testdata-lisatiedot}                               Ei mulla mitään lisätietoja ole
 
 
@@ -66,6 +67,9 @@ Verify all buttons, selections and fields
     Capture Page Screenshot
     # Lisää koulun nimi
     Input Text                                              ${lomake-koulun-nimi-input}                                 ${lomake-testdata-koulunnimi}
+    Capture Page Screenshot
+    # Lisää todistuksen antamisvuosi
+    Input Text                                              ${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}           ${lomake-testdata-todistuksen-antamisvuosi}      
     Capture Page Screenshot
     # Valitse toimitustavaksi nouto
     Click Element                                           ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}

--- a/test/tests/lomake-Check-tjpt-page-functionality-and-logout.robot
+++ b/test/tests/lomake-Check-tjpt-page-functionality-and-logout.robot
@@ -63,6 +63,9 @@ Verify all buttons, selections and fields
     # Lisää koulun nimi
     Input Text                                              ${lomake-koulun-nimi-input}                                 Mauri Makkaran ala-aste
     Capture Page Screenshot
+    # Lisää todistuksen antamisvuosi
+    Input Text                                              ${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}           2002      
+    Capture Page Screenshot
     # Valitse toimitustavaksi nouto
     Click Element                                           ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}
     Wait Until Page Contains                                Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta   20

--- a/test/tests/lomake-direct-lomake-url.robot
+++ b/test/tests/lomake-direct-lomake-url.robot
@@ -47,6 +47,9 @@ Fill lomake and send
     # Lisää koulun nimi
     Input Text                                              ${lomake-koulun-nimi-input}                                 ${koulun-nimi}
     Capture Page Screenshot
+    # Lisää todistuksen antamisvuosi
+    Input Text                                              ${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}           2003      
+    Capture Page Screenshot
     # Valitse toimitustavaksi nouto
     Click Element                                           ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}
     Wait Until Page Contains                                Noudetaan kasvatuksen ja koulutuksen toimialan arkistolta   20

--- a/test/tests/lomake-direct-url-and-content-in-mail.robot
+++ b/test/tests/lomake-direct-url-and-content-in-mail.robot
@@ -64,6 +64,9 @@ Fill form and send
     # Lisää koulun nimi
     Input Text                                              ${lomake-koulun-nimi-input}                                 ${koulun-nimi}
     Capture Page Screenshot
+    # Lisää todistuksen antamisvuosi
+    Input Text                                              ${lomake-tjpt-vtt-todistuksen-antamisvuosi-input}           2004      
+    Capture Page Screenshot
     # Valitse toimitustavaksi nouto
     Click Element                                           ${lomake-tjpt-toimitustapa-nouto-radiobutton-FI}
     Wait Until Page Contains                                ${nouto-viesti}                                             20


### PR DESCRIPTION
# [LOM-511](https://helsinkisolutionoffice.atlassian.net/browse/LOM-511)

## What was done
Todistuksen antamisvuosi steps added

[LOM-511]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ