### PR TITLE
LOM-523: fix: LOM-523: fix missing swedish translations

### DIFF
--- a/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
+++ b/conf/cmi/language/sv/webform.webform.todistusjaljennospyynto_tilaus.yml
@@ -29,10 +29,10 @@ elements: |
     '#title': Leveransmetod
   valitse_toimitustapa:
     '#title': 'Välj leveransmetod'
-    '#Nouto -teksti__title': 'Hämtas från fostrans- och utbildningssektorns arkiv. Töysänkatu 2 D, 00510 Helsinki'
+    '#Nouto -teksti__title': 'Hämtas från fostrans- och utbildningssektorns arkiv. Töysägatan 2 D, 00510 Helsingfors'
     '#Info__title': ''
     '#Toimitustapa: Postiennakko__title': Postförskott
-    '#Toimitustapa: Nouto__title': 'Upphämtning. Hämtas från fostrans- och utbildningssektorns arkiv. Töysänkatu 2 D, 00510 Helsinki.'
+    '#Toimitustapa: Nouto__title': 'Upphämtning. Hämtas från fostrans- och utbildningssektorns arkiv. Töysägatan 2 D, 00510 Helsingfors.'
     '#delivery_method__title': ''
     '#first_name__title': Förnamn
     '#last_name__title': Efternamn

--- a/public/modules/custom/form_tool_share/translations/sv.po
+++ b/public/modules/custom/form_tool_share/translations/sv.po
@@ -28,4 +28,4 @@ msgid "Submit error"
 msgstr "Skicka fel"
 
 msgid "Form information"
-msgstr "Forminformation"
+msgstr "Blanketinformation"

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/fi/fi.po
@@ -43,6 +43,9 @@ msgstr "Kaupunki"
 msgid "Phone Number"
 msgstr "Puhelinnumero"
 
+msgid "Pick-up from Töysänkatu 2 D, 00510 Helsinki."
+msgstr "Nouto osoitteesta Töysänkatu 2 D, 00510 Helsinki."
+
 msgid "Cash on delivery price is 9,20 €"
 msgstr "Postiennakon hinta asiakirjan tilaajalle 9,20 €"
 

--- a/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/sv/sv.po
+++ b/public/modules/custom/form_tool_webform_components/form_tool_contact_info/translations/sv/sv.po
@@ -5,6 +5,9 @@ msgctxt "Notification inside a webform"
 msgid "Notification"
 msgstr "Meddelande"
 
+msgid "Pick-up from Töysänkatu 2 D, 00510 Helsinki."
+msgstr "Upphämtning från Töysägatan 2 D, 00510 Helsingfors."
+
 msgid "Collect. The document will be picked up from the Education Division's archive. Töysänkatu 2 D, 00510 Helsinki."
 msgstr "Upphämtning. Hämtas från fostrans- och utbildningssektorns arkiv. Töysägatan 2 D, 00510 Helsingfors."
 

--- a/public/modules/custom/webform_formtool_handler/src/EventSubscriber/WebformSubmissionSubscriber.php
+++ b/public/modules/custom/webform_formtool_handler/src/EventSubscriber/WebformSubmissionSubscriber.php
@@ -3,7 +3,6 @@
 namespace Drupal\webform_formtool_handler\EventSubscriber;
 
 use Drupal\Core\Logger\LoggerChannelFactory;
-use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\webform_formtool_handler\Event\WebformSubmissionEvent;
 use GuzzleHttp\ClientInterface;
@@ -38,9 +37,10 @@ class WebformSubmissionSubscriber implements EventSubscriberInterface {
   /**
    * Send POST request to service.
    *
-   * @param WebformSubmissionEvent $event
+   * @param \Drupal\webform_formtool_handler\Event\WebformSubmissionEvent $event
    *   A WebformSubmissionEvent event.
-   * @throws GuzzleException
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function onSubmissionCreate(WebformSubmissionEvent $event) {
 


### PR DESCRIPTION
# [LOM-523](https://helsinkisolutionoffice.atlassian.net/browse/LOM-523)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Swedish translations to conf files.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/LOM-523-swedish-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards


[LOM-523]: https://helsinkisolutionoffice.atlassian.net/browse/LOM-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ